### PR TITLE
claude/hetzner-remote-dev-setup-7KLyN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,124 @@ vm/switch:
 		sudo NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nixos-rebuild switch --flake \"/nix-config#${NIXNAME}\" \
 	"
 
+# =============================================================================
+# Hetzner Dedicated Server Bootstrap
+# =============================================================================
+#
+# Prerequisites:
+#   1. Order a Hetzner dedicated server
+#   2. Boot into Rescue System (Linux 64-bit) from Hetzner Robot
+#   3. Note the IP address
+#
+# Bootstrap process:
+#   make hetzner/bootstrap0 NIXADDR=<ip>   # Partition, install NixOS, reboot
+#   make hetzner/bootstrap NIXADDR=<ip>    # Copy config, apply, copy secrets
+#
+# After bootstrap:
+#   make hetzner/switch NIXADDR=<ip>       # Apply config changes
+#   ssh hetzner-dev                        # Connect (uses ~/.ssh/config)
+
+HETZNER_SSH_OPTIONS=-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+
+# Initial NixOS installation on Hetzner rescue system
+# This partitions drives, installs NixOS, and reboots
+hetzner/bootstrap0:
+	@echo "==> Bootstrapping NixOS on Hetzner ($(NIXADDR))"
+	@echo "==> This will WIPE ALL DATA on the server!"
+	@echo "==> Press Ctrl+C within 5 seconds to abort..."
+	@sleep 5
+	ssh $(HETZNER_SSH_OPTIONS) root@$(NIXADDR) " \
+		set -e; \
+		echo '==> Detecting primary disk...'; \
+		DISK=$$(lsblk -d -o NAME,SIZE --noheadings | grep -E 'nvme|sd' | head -1 | awk '{print \"/dev/\" \$$1}'); \
+		echo \"==> Using disk: \$$DISK\"; \
+		echo '==> Partitioning disk...'; \
+		parted \$$DISK -- mklabel gpt; \
+		parted \$$DISK -- mkpart primary 512MB -8GB; \
+		parted \$$DISK -- mkpart primary linux-swap -8GB 100%; \
+		parted \$$DISK -- mkpart ESP fat32 1MB 512MB; \
+		parted \$$DISK -- set 3 esp on; \
+		sleep 2; \
+		echo '==> Formatting partitions...'; \
+		mkfs.ext4 -L nixos \$${DISK}p1 || mkfs.ext4 -L nixos \$${DISK}1; \
+		mkswap -L swap \$${DISK}p2 || mkswap -L swap \$${DISK}2; \
+		mkfs.fat -F 32 -n boot \$${DISK}p3 || mkfs.fat -F 32 -n boot \$${DISK}3; \
+		sleep 1; \
+		echo '==> Mounting filesystems...'; \
+		mount /dev/disk/by-label/nixos /mnt; \
+		mkdir -p /mnt/boot; \
+		mount /dev/disk/by-label/boot /mnt/boot; \
+		swapon /dev/disk/by-label/swap; \
+		echo '==> Generating hardware config...'; \
+		nixos-generate-config --root /mnt; \
+		echo '==> Configuring initial NixOS...'; \
+		sed --in-place '/system\.stateVersion = .*/a \
+			nix.package = pkgs.nixVersions.latest;\n \
+			nix.extraOptions = \"experimental-features = nix-command flakes\";\n \
+			nix.settings.substituters = [\"https://javdl-nixos-config.cachix.org\" \"https://cache.nixos.org\"];\n \
+			nix.settings.trusted-public-keys = [\"javdl-nixos-config.cachix.org-1:6xuHXHavvpdfBLQq+RzxDAMxhWkea0NaYvLtDssDJIU=\" \"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=\"];\n \
+			services.openssh.enable = true;\n \
+			services.openssh.settings.PasswordAuthentication = true;\n \
+			services.openssh.settings.PermitRootLogin = \"yes\";\n \
+			users.users.root.initialPassword = \"nixos\";\n \
+		' /mnt/etc/nixos/configuration.nix; \
+		echo '==> Installing NixOS (this takes a while)...'; \
+		nixos-install --no-root-passwd; \
+		echo '==> Installation complete! Rebooting...'; \
+		reboot; \
+	"
+
+# After bootstrap0, copy our config and apply it
+hetzner/bootstrap:
+	@echo "==> Copying configuration to Hetzner..."
+	NIXUSER=root $(MAKE) hetzner/copy
+	@echo "==> Applying NixOS configuration..."
+	NIXUSER=root $(MAKE) hetzner/switch NIXNAME=hetzner-dev
+	@echo "==> Copying secrets..."
+	$(MAKE) hetzner/secrets
+	@echo "==> Bootstrap complete! Rebooting..."
+	ssh $(HETZNER_SSH_OPTIONS) -p$(NIXPORT) $(NIXUSER)@$(NIXADDR) "sudo reboot" || true
+
+# Copy configuration to Hetzner server
+hetzner/copy:
+	rsync -av -e 'ssh $(HETZNER_SSH_OPTIONS) -p$(NIXPORT)' \
+		--exclude='vendor/' \
+		--exclude='.git/' \
+		--exclude='.git-crypt/' \
+		--exclude='.jj/' \
+		--exclude='iso/' \
+		--rsync-path="sudo rsync" \
+		$(MAKEFILE_DIR)/ $(NIXUSER)@$(NIXADDR):/nix-config
+
+# Apply NixOS configuration on Hetzner
+hetzner/switch:
+	ssh $(HETZNER_SSH_OPTIONS) -p$(NIXPORT) $(NIXUSER)@$(NIXADDR) " \
+		sudo NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nixos-rebuild switch --flake \"/nix-config#$(NIXNAME)\" \
+	"
+
+# Copy secrets (SSH keys, GPG) to Hetzner
+hetzner/secrets:
+	@echo "==> Copying GPG keyring..."
+	rsync -av -e 'ssh $(HETZNER_SSH_OPTIONS) -p$(NIXPORT)' \
+		--exclude='.#*' \
+		--exclude='S.*' \
+		--exclude='*.conf' \
+		$(HOME)/.gnupg/ $(NIXUSER)@$(NIXADDR):~/.gnupg
+	@echo "==> Copying SSH keys..."
+	rsync -av -e 'ssh $(HETZNER_SSH_OPTIONS) -p$(NIXPORT)' \
+		--exclude='environment' \
+		$(HOME)/.ssh/ $(NIXUSER)@$(NIXADDR):~/.ssh
+
+# Fetch hardware config from Hetzner (run after bootstrap0, before bootstrap)
+hetzner/fetch-hardware:
+	@echo "==> Fetching hardware configuration from Hetzner..."
+	scp $(HETZNER_SSH_OPTIONS) -P$(NIXPORT) root@$(NIXADDR):/mnt/etc/nixos/hardware-configuration.nix \
+		$(MAKEFILE_DIR)/hosts/hardware/hetzner-dev.nix
+	@echo "==> Hardware config saved to hosts/hardware/hetzner-dev.nix"
+	@echo "==> Review and commit this file to git"
+
+# =============================================================================
+
 # Build a WSL installer
 .PHONY: wsl
 wsl:

--- a/flake.nix
+++ b/flake.nix
@@ -174,6 +174,11 @@
       user   = "joost";
     };
 
+    nixosConfigurations.hetzner-dev = mkSystem "hetzner-dev" {
+      system = "x86_64-linux";
+      user   = "joost";
+    };
+
     darwinConfigurations.macbook-pro-m1 = mkSystem "macbook-pro-m1" {
       system = "aarch64-darwin";
       user   = "joost";

--- a/hosts/hardware/hetzner-dev.nix
+++ b/hosts/hardware/hetzner-dev.nix
@@ -1,0 +1,55 @@
+# Hardware configuration for Hetzner dedicated server
+#
+# This is a placeholder that will be replaced by `nixos-generate-config`
+# during the bootstrap process. The bootstrap script will:
+#   1. Partition the drives
+#   2. Run nixos-generate-config
+#   3. Copy the generated hardware config here
+#
+# After bootstrap, commit the actual hardware configuration to git.
+
+{ config, lib, pkgs, modulesPath, ... }:
+
+{
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+    (modulesPath + "/profiles/qemu-guest.nix")  # Remove if not a VM/cloud instance
+  ];
+
+  # Common modules for Hetzner servers (NVMe, AHCI, USB)
+  boot.initrd.availableKernelModules = [
+    "nvme"
+    "ahci"
+    "xhci_pci"
+    "virtio_pci"
+    "virtio_scsi"
+    "sd_mod"
+    "sr_mod"
+  ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ "kvm-intel" "kvm-amd" ];  # Virtualization support
+  boot.extraModulePackages = [ ];
+
+  # Filesystem configuration (matches bootstrap0 partitioning)
+  # These use labels which are set during partitioning
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-label/boot";
+    fsType = "vfat";
+  };
+
+  swapDevices = [
+    { device = "/dev/disk/by-label/swap"; }
+  ];
+
+  # Platform
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+
+  # CPU microcode updates (enable the relevant one based on your CPU)
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+  # hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+}

--- a/hosts/hetzner-dev.nix
+++ b/hosts/hetzner-dev.nix
@@ -1,0 +1,157 @@
+{ config, pkgs, lib, ... }:
+
+# Hetzner dedicated server for remote development with Claude Code + tmux
+#
+# Bootstrap process:
+#   1. Boot Hetzner server into rescue mode (Linux 64-bit)
+#   2. Run: make hetzner/bootstrap0 NIXADDR=<ip>
+#   3. After reboot: make hetzner/bootstrap NIXADDR=<ip>
+#   4. Connect: ssh hetzner-dev (uses ~/.ssh config)
+
+{
+  imports = [
+    ./hardware/hetzner-dev.nix
+    ../modules/cachix.nix
+  ];
+
+  # Latest kernel for best hardware support
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
+  # Use systemd-boot for UEFI
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  # Hostname
+  networking.hostName = "hetzner-dev";
+
+  # Timezone (UTC for servers)
+  time.timeZone = "UTC";
+
+  # Nix configuration
+  nix = {
+    package = pkgs.nixVersions.latest;
+    extraOptions = ''
+      experimental-features = nix-command flakes
+      keep-outputs = true
+      keep-derivations = true
+    '';
+
+    # Garbage collection
+    gc = {
+      automatic = true;
+      randomizedDelaySec = "14m";
+      options = "--delete-older-than 30d";
+    };
+  };
+
+  # Allow unfree packages
+  nixpkgs.config.allowUnfree = true;
+  nixpkgs.config.allowUnfreePredicate = _: true;
+
+  # Networking - Hetzner typically uses static IP or DHCP on main interface
+  networking.useDHCP = false;
+  networking.interfaces.eth0.useDHCP = true;  # Adjust interface name as needed
+
+  # Firewall
+  networking.firewall = {
+    enable = true;
+    allowedTCPPorts = [ 22 ];  # SSH only by default
+    # Add more ports as needed: 80 443 for web, etc.
+  };
+
+  # SSH daemon - key-only auth for security
+  services.openssh = {
+    enable = true;
+    settings = {
+      PasswordAuthentication = false;
+      PermitRootLogin = "prohibit-password";  # Allow root with key for initial setup
+      KbdInteractiveAuthentication = false;
+    };
+  };
+
+  # Don't require password for sudo (convenient for remote dev)
+  security.sudo.wheelNeedsPassword = false;
+
+  # Immutable users (passwords managed via config)
+  users.mutableUsers = false;
+
+  # Docker for containerized development
+  virtualisation.docker.enable = true;
+
+  # System packages for remote development
+  environment.systemPackages = with pkgs; [
+    # Essentials
+    git
+    gnumake
+    htop
+    btop
+    tmux
+
+    # Network tools
+    curl
+    wget
+    rsync
+
+    # Development
+    gcc
+    gnumake
+
+    # Editors
+    neovim
+
+    # Utils
+    jq
+    ripgrep
+    fd
+    tree
+    unzip
+    zip
+  ];
+
+  # Locale
+  i18n.defaultLocale = "en_US.UTF-8";
+
+  # System limits for development workloads
+  boot.kernel.sysctl = {
+    # Increase inotify limits for file watching (Claude Code, IDEs)
+    "fs.inotify.max_user_watches" = 524288;
+    "fs.inotify.max_user_instances" = 512;
+
+    # Increase file descriptor limits
+    "fs.file-max" = 2097152;
+
+    # Network optimizations
+    "net.core.somaxconn" = 65535;
+  };
+
+  # PAM limits
+  security.pam.loginLimits = [
+    {
+      domain = "*";
+      type = "soft";
+      item = "nofile";
+      value = "65536";
+    }
+    {
+      domain = "*";
+      type = "hard";
+      item = "nofile";
+      value = "65536";
+    }
+  ];
+
+  # Disable unnecessary services for a headless server
+  services.xserver.enable = false;
+  services.printing.enable = false;
+  hardware.pulseaudio.enable = false;
+
+  # Enable useful services
+  services.nscd.enable = true;
+  services.dbus.enable = true;
+
+  # Tailscale for easy secure access (optional - enable with tailscale up)
+  services.tailscale.enable = true;
+
+  # This value determines the NixOS release
+  system.stateVersion = "25.05";
+}

--- a/users/joost/home-manager.nix
+++ b/users/joost/home-manager.nix
@@ -753,6 +753,15 @@ in {
         identityFile = "~/.ssh/id_ed25519_hetzner_work";
         identitiesOnly = true;
       };
+
+      # Hetzner remote dev server - update hostname after bootstrap
+      "hetzner-dev" = {
+        hostname = "YOUR_HETZNER_IP";  # TODO: Update with actual IP/hostname
+        user = "joost";
+        identityFile = "~/.ssh/id_ed25519";
+        identitiesOnly = true;
+        forwardAgent = true;  # Forward SSH agent for git operations
+      };
     };
   };
 


### PR DESCRIPTION
- Add hosts/hetzner-dev.nix: Minimal headless server config optimized for remote development with Claude Code and tmux
- Add hosts/hardware/hetzner-dev.nix: Placeholder hardware config (to be replaced by nixos-generate-config during bootstrap)
- Add flake.nix entry for hetzner-dev
- Add Makefile targets: hetzner/bootstrap0, hetzner/bootstrap, hetzner/copy, hetzner/switch, hetzner/secrets, hetzner/fetch-hardware
- Add SSH config entry for hetzner-dev in home-manager

Bootstrap process:
1. Boot Hetzner rescue system
2. make hetzner/bootstrap0 NIXADDR=<ip>
3. make hetzner/bootstrap NIXADDR=<ip>
4. Update SSH config hostname and connect: ssh hetzner-dev