### PR TITLE
Remove source-built packages to speed up nix switch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -156,27 +156,6 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1767609335,
-        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
@@ -555,46 +534,10 @@
         "type": "github"
       }
     },
-    "neovim-nightly-overlay": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "neovim-src": "neovim-src",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1767830720,
-        "narHash": "sha256-QkoscipfDnwclEnVughLSycbkv69yYbxzBLeSWWVAvM=",
-        "owner": "nix-community",
-        "repo": "neovim-nightly-overlay",
-        "rev": "bc28e1651ac22277c1b8d77916944a3a462d875b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "neovim-nightly-overlay",
-        "type": "github"
-      }
-    },
-    "neovim-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767829782,
-        "narHash": "sha256-ZICnwVq/gDcG8KjRTLFk4fI9nvrVJNGORnNdHEG5iZI=",
-        "owner": "neovim",
-        "repo": "neovim",
-        "rev": "89960e27d6f131587e6e97602be947fdedd8de7a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "neovim",
-        "repo": "neovim",
-        "type": "github"
-      }
-    },
     "nix-snapd": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -713,22 +656,6 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1767364772,
-        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1767799921,
         "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
         "owner": "nixos",
@@ -772,11 +699,10 @@
         "fh": "fh",
         "home-manager": "home-manager",
         "hyprland": "hyprland",
-        "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nix-snapd": "nix-snapd",
         "nixos-hardware": "nixos-hardware",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -34,13 +34,6 @@
 
     hyprland.url = "github:hyprwm/Hyprland";
 
-    # I think technically you're not supposed to override the nixpkgs
-    # used by neovim but recently I had failures if I didn't pin to my
-    # own. We can always try to remove that anytime.
-    neovim-nightly-overlay = {
-      url = "github:nix-community/neovim-nightly-overlay";
-    };
-
     # Other packages
     # jujutsu.url = "github:martinvonz/jj";
     # zig.url = "github:mitchellh/zig-overlay";
@@ -66,23 +59,6 @@
 
           # Want the latest version of these
           nushell = pkgs-unstable.nushell;
-
-          # Fix setproctitle test failures on macOS
-          python3 = prev.python3.override {
-            packageOverrides = pyFinal: pyPrev: {
-              setproctitle = pyPrev.setproctitle.overridePythonAttrs (old: {
-                doCheck = false;
-              });
-            };
-          };
-
-          python313 = prev.python313.override {
-            packageOverrides = pyFinal: pyPrev: {
-              setproctitle = pyPrev.setproctitle.overridePythonAttrs (old: {
-                doCheck = false;
-              });
-            };
-          };
         })
     ];
 

--- a/users/joost/home-manager.nix
+++ b/users/joost/home-manager.nix
@@ -925,7 +925,6 @@ in {
 
   programs.neovim = {
     enable = true;
-    package = inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
     withPython3 = true;
     extraPython3Packages = (p: with p; [


### PR DESCRIPTION
## Summary
- Remove neovim-nightly-overlay input and use stable neovim from nixpkgs instead
- Remove python3/python313 setproctitle test-disabling overrides that triggered full Python rebuilds
- Update flake.lock to remove 5 neovim-nightly related inputs

## Motivation
These source-built packages were significantly slowing down `make switch` times. By switching to binary-cached alternatives:
- Neovim now uses stable 0.11.5 from nixpkgs binary cache
- Python packages no longer need custom rebuilds

## Test plan
- [x] `nix build ".#darwinConfigurations.j8.system" --dry-run` succeeds
- [ ] `make switch` completes faster than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)