### PR TITLE
Add MicroVM support to loom Hetzner server

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,69 @@ $ wsl -s nixos
 After the `wsl -d` command, you should be dropped into the Nix environment.
 _Voila!_
 
+## Setup (Hetzner Server)
+
+For dedicated Hetzner servers like `hetzner-dev` or `loom`:
+
+1. Boot the server into rescue mode (Linux 64-bit) via Hetzner Robot console
+2. Run initial bootstrap:
+   ```bash
+   make hetzner/bootstrap0 NIXADDR=<ip> NIXNAME=loom
+   ```
+3. After reboot, complete setup:
+   ```bash
+   make hetzner/bootstrap NIXADDR=<ip> NIXNAME=loom
+   ```
+4. Copy SSH/GPG keys:
+   ```bash
+   make hetzner/secrets NIXADDR=<ip>
+   ```
+5. Setup Tailscale (generate key at https://login.tailscale.com/admin/settings/keys):
+   ```bash
+   make hetzner/tailscale-auth NIXADDR=<ip> TAILSCALE_AUTHKEY=<key>
+   ```
+
+### MicroVM Setup (Loom Server)
+
+The `loom` server supports MicroVMs for running isolated Claude Code agents. After the base setup:
+
+1. Create workspace and SSH host keys for the VM:
+   ```bash
+   mkdir -p ~/microvm/dev/ssh-host-keys
+   ssh-keygen -t ed25519 -N "" -f ~/microvm/dev/ssh-host-keys/ssh_host_ed25519_key
+   cp ~/.ssh/authorized_keys ~/microvm/dev/ssh-host-keys/
+   ```
+
+2. Create Claude credentials directory:
+   ```bash
+   mkdir -p ~/claude-microvm
+   # Copy .claude.json and settings.json here if needed
+   ```
+
+3. Start the VM:
+   ```bash
+   sudo systemctl start microvm@devvm
+   ```
+
+4. SSH into the VM:
+   ```bash
+   ssh agent@192.168.83.2
+   ```
+
+5. Run Claude Code:
+   ```bash
+   cd /workspace
+   claude --dangerously-skip-permissions
+   ```
+
+**VM Management:**
+- Start: `sudo systemctl start microvm@devvm`
+- Stop: `sudo systemctl stop microvm@devvm`
+- Status: `sudo systemctl status microvm@devvm`
+- Logs: `journalctl -u microvm@devvm`
+
+**Network:** VMs are on `192.168.83.0/24` with NAT to the internet via the host.
+
 ## Passwords
 
 Create hashed password with `mkpasswd` to put in `users/joost/nixos.nix`

--- a/flake.lock
+++ b/flake.lock
@@ -555,6 +555,27 @@
         "type": "github"
       }
     },
+    "microvm": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "spectrum": "spectrum"
+      },
+      "locked": {
+        "lastModified": 1770074118,
+        "narHash": "sha256-3JFYOqJGLgn5QsEnBwOm6K+vFX3uckiiyVt3b9VT5h0=",
+        "owner": "astro",
+        "repo": "microvm.nix",
+        "rev": "4f7e75d2be8a4c99778275ad3b3e4421029dcde0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "astro",
+        "repo": "microvm.nix",
+        "type": "github"
+      }
+    },
     "neovim-nightly-overlay": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -772,6 +793,7 @@
         "fh": "fh",
         "home-manager": "home-manager",
         "hyprland": "hyprland",
+        "microvm": "microvm",
         "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nix-snapd": "nix-snapd",
         "nixos-hardware": "nixos-hardware",
@@ -816,6 +838,22 @@
         "owner": "Mic92",
         "repo": "sops-nix",
         "type": "github"
+      }
+    },
+    "spectrum": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1759482047,
+        "narHash": "sha256-H1wiXRQHxxPyMMlP39ce3ROKCwI5/tUn36P8x6dFiiQ=",
+        "ref": "refs/heads/main",
+        "rev": "c5d5786d3dc938af0b279c542d1e43bce381b4b9",
+        "revCount": 996,
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,12 @@
 
     hyprland.url = "github:hyprwm/Hyprland";
 
+    # MicroVM support for isolated coding agents
+    microvm = {
+      url = "github:astro/microvm.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # I think technically you're not supposed to override the nixpkgs
     # used by neovim but recently I had failures if I didn't pin to my
     # own. We can always try to remove that anytime.
@@ -236,6 +242,12 @@
     };
 
     nixosConfigurations.hetzner-dev = mkSystem "hetzner-dev" {
+      system = "x86_64-linux";
+      user   = "joost";
+      server = true;
+    };
+
+    nixosConfigurations.loom = mkSystem "loom" {
       system = "x86_64-linux";
       user   = "joost";
       server = true;

--- a/hosts/hardware/loom.nix
+++ b/hosts/hardware/loom.nix
@@ -1,0 +1,55 @@
+# Hardware configuration for Hetzner loom server
+#
+# This is a placeholder that will be replaced by `nixos-generate-config`
+# during the bootstrap process. The bootstrap script will:
+#   1. Partition the drives
+#   2. Run nixos-generate-config
+#   3. Copy the generated hardware config here
+#
+# After bootstrap, commit the actual hardware configuration to git.
+
+{ config, lib, pkgs, modulesPath, ... }:
+
+{
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+    (modulesPath + "/profiles/qemu-guest.nix")  # Remove if not a VM/cloud instance
+  ];
+
+  # Common modules for Hetzner servers (NVMe, AHCI, USB)
+  boot.initrd.availableKernelModules = [
+    "nvme"
+    "ahci"
+    "xhci_pci"
+    "virtio_pci"
+    "virtio_scsi"
+    "sd_mod"
+    "sr_mod"
+  ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ "kvm-intel" "kvm-amd" ];  # Virtualization support
+  boot.extraModulePackages = [ ];
+
+  # Filesystem configuration (matches bootstrap0 partitioning)
+  # These use labels which are set during partitioning
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-label/boot";
+    fsType = "vfat";
+  };
+
+  swapDevices = [
+    { device = "/dev/disk/by-label/swap"; }
+  ];
+
+  # Platform
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+
+  # CPU microcode updates (enable the relevant one based on your CPU)
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+  # hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+}

--- a/hosts/loom-microvms.nix
+++ b/hosts/loom-microvms.nix
@@ -1,0 +1,56 @@
+# MicroVM definitions for loom server
+#
+# This file defines the MicroVMs that run on the loom Hetzner server.
+# Each VM provides an isolated environment for Claude Code development.
+#
+# Management:
+#   Start VM:  sudo systemctl start microvm@devvm
+#   Stop VM:   sudo systemctl stop microvm@devvm
+#   Status:    sudo systemctl status microvm@devvm
+#   SSH:       ssh agent@192.168.83.2
+#
+# Setup (one-time on host):
+#   mkdir -p ~/microvm/dev/ssh-host-keys
+#   ssh-keygen -t ed25519 -N "" -f ~/microvm/dev/ssh-host-keys/ssh_host_ed25519_key
+#   cp ~/.ssh/authorized_keys ~/microvm/dev/ssh-host-keys/
+#   mkdir -p ~/claude-microvm
+
+{ config, pkgs, lib, inputs, ... }:
+
+{
+  # Development VM for Claude Code
+  microvm.vms.devvm = {
+    autostart = false;  # Start manually when needed
+
+    # Pass inputs to the VM's module system
+    specialArgs = { inherit inputs; };
+
+    config = import ../modules/microvm/base.nix {
+      hostName = "devvm";
+      ipAddress = "192.168.83.2/24";
+      tapId = "01";
+      mac = "02:00:00:00:00:01";
+      workspace = "/home/joost/microvm/dev";
+      vcpu = 8;
+      mem = 4096;
+      extraPackages = with pkgs; [
+        # Add any extra packages for this VM
+        nodejs
+        python3
+      ];
+    };
+  };
+
+  # Example: Add more VMs as needed
+  # microvm.vms.testvm = {
+  #   autostart = false;
+  #   specialArgs = { inherit inputs; };
+  #   config = import ../modules/microvm/base.nix {
+  #     hostName = "testvm";
+  #     ipAddress = "192.168.83.3/24";
+  #     tapId = "02";
+  #     mac = "02:00:00:00:00:02";
+  #     workspace = "/home/joost/microvm/test";
+  #   };
+  # };
+}

--- a/hosts/loom.nix
+++ b/hosts/loom.nix
@@ -1,0 +1,258 @@
+{ config, pkgs, lib, inputs, ... }:
+
+# Loom - Hetzner dedicated server for MicroVM-based coding agents
+#
+# This server hosts isolated MicroVMs for running Claude Code in secure,
+# ephemeral environments. Based on:
+# https://michael.stapelberg.ch/posts/2026-02-01-coding-agent-microvm-nix/
+#
+# Bootstrap process:
+#   1. Boot Hetzner server into rescue mode (Linux 64-bit)
+#   2. Run: make hetzner/bootstrap0 NIXADDR=<ip> NIXNAME=loom
+#   3. After reboot: make hetzner/bootstrap NIXADDR=<ip> NIXNAME=loom
+#   4. Connect: ssh loom (uses ~/.ssh config)
+#
+# MicroVM setup (after bootstrap):
+#   mkdir -p ~/microvm/dev/ssh-host-keys
+#   ssh-keygen -t ed25519 -N "" -f ~/microvm/dev/ssh-host-keys/ssh_host_ed25519_key
+#   cp ~/.ssh/authorized_keys ~/microvm/dev/ssh-host-keys/
+#   mkdir -p ~/claude-microvm
+#   sudo systemctl start microvm@devvm
+
+{
+  imports = [
+    ./hardware/loom.nix
+    ../modules/cachix.nix
+    ../modules/secrets.nix
+    ../modules/automatic-nix-gc.nix
+    ../modules/nixos-auto-update.nix
+    ../modules/security-audit.nix
+    ../modules/podman.nix
+    ../modules/microvm/host.nix
+    ./loom-microvms.nix
+    inputs.microvm.nixosModules.host
+  ];
+
+  # Latest kernel for best hardware support
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
+  # Use systemd-boot for UEFI
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  # Hostname
+  networking.hostName = "loom";
+
+  # Timezone (UTC for servers)
+  time.timeZone = "UTC";
+
+  # Nix configuration
+  nix = {
+    package = pkgs.nixVersions.latest;
+    extraOptions = ''
+      experimental-features = nix-command flakes
+      keep-outputs = true
+      keep-derivations = true
+    '';
+  };
+
+  # Disk-based garbage collection (only runs when disk space is low)
+  services.automaticNixGC = {
+    enable = true;
+    minFreeGB = 50;          # Trigger GC during builds below 50GB
+    maxFreeGB = 100;         # Target 100GB after build-time GC
+    scheduledThresholdGB = 50; # Daily check: GC if below 50GB
+    keepDays = 14;           # Keep generations from last 14 days
+  };
+
+  # Automatic NixOS updates from git repository
+  services.nixosAutoUpdate = {
+    enable = true;
+    flake = "github:javdl/nixos-config#loom";
+    dates = "04:00";                # Check at 4 AM
+    randomizedDelaySec = "30m";     # Random delay up to 30 min
+    allowReboot = false;            # Don't auto-reboot
+  };
+
+  # Security auditing with auditd
+  services.securityAudit = {
+    enable = true;
+    failureMode = "printk";  # Log audit failures to kernel log
+    maxLogFile = 50;         # Rotate at 50MB
+    numLogs = 10;            # Keep 10 log files
+  };
+
+  # Allow unfree packages
+  nixpkgs.config.allowUnfree = true;
+  nixpkgs.config.allowUnfreePredicate = _: true;
+
+  # MicroVM host configuration
+  services.microvmHost = {
+    enable = true;
+    externalInterface = "enp1s0";
+  };
+
+  # Networking - dual stack (IPv4 via DHCP + static IPv6)
+  # Note: systemd-networkd is enabled by microvmHost module
+  networking.useNetworkd = true;  # Use systemd-networkd for consistency with microvm bridge
+  networking.useDHCP = true;
+  networking.interfaces.enp1s0.ipv6.addresses = [{
+    address = "2a01:4f8:1c1f:ad3c::1";  # Update with actual IPv6
+    prefixLength = 64;
+  }];
+  networking.defaultGateway6 = {
+    address = "fe80::1";
+    interface = "enp1s0";
+  };
+
+  # Firewall - base config (Tailscale settings added below)
+  networking.firewall.enable = true;
+  networking.firewall.allowedTCPPorts = [ 22 ];  # SSH on public IP
+
+  # SSH daemon - key-only auth for security
+  services.openssh = {
+    enable = true;
+    settings = {
+      PasswordAuthentication = false;
+      PermitRootLogin = "prohibit-password";  # Allow root with key for initial setup
+      KbdInteractiveAuthentication = false;
+    };
+  };
+
+  # Don't require password for sudo (convenient for remote dev)
+  security.sudo.wheelNeedsPassword = false;
+
+  # Immutable users (passwords managed via config)
+  users.mutableUsers = false;
+
+  # Docker for containerized development
+  virtualisation.docker.enable = true;
+
+  # Podman for rootless containers (Docker alternative with better security)
+  virtualisation.podmanConfig = {
+    enable = true;
+    dockerCompat = false;  # Don't conflict with Docker
+    autoPrune = true;      # Weekly cleanup of unused images
+  };
+
+  # System packages for remote development and MicroVM management
+  environment.systemPackages = with pkgs; [
+    # Essentials
+    git
+    gnumake
+    htop
+    btop
+    tmux
+
+    # Network tools
+    curl
+    wget
+    rsync
+
+    # Development
+    gcc
+    gnumake
+
+    # Editors
+    neovim
+
+    # Utils
+    jq
+    ripgrep
+    fd
+    tree
+    unzip
+    zip
+
+    # Safety: require typing hostname to confirm shutdown/reboot via SSH
+    molly-guard
+  ];
+
+  # Locale
+  i18n.defaultLocale = "en_US.UTF-8";
+
+  # Use zsh as default shell
+  programs.zsh.enable = true;
+  users.users.joost.shell = lib.mkForce pkgs.zsh;
+
+  # Run dynamically linked binaries (AppImages, prebuilt tools) without patchelf
+  programs.nix-ld.enable = true;
+
+  # Load BBR TCP congestion control module
+  boot.kernelModules = [ "tcp_bbr" ];
+
+  # System limits and performance tuning
+  boot.kernel.sysctl = {
+    # Increase inotify limits for file watching (Claude Code, IDEs)
+    "fs.inotify.max_user_watches" = 524288;
+    "fs.inotify.max_user_instances" = 512;
+
+    # Increase file descriptor limits
+    "fs.file-max" = 2097152;
+
+    # Process limits (64-bit max)
+    "kernel.pid_max" = 4194303;
+
+    # Network optimizations
+    "net.core.somaxconn" = 65535;
+
+    # TCP BBR congestion control (better performance, especially on lossy networks)
+    "net.ipv4.tcp_congestion_control" = "bbr";
+    "net.core.default_qdisc" = "fq";
+
+    # Larger socket buffers for high-throughput connections
+    "net.core.rmem_max" = 16777216;
+    "net.core.wmem_max" = 16777216;
+    "net.ipv4.tcp_rmem" = "4096 87380 16777216";
+    "net.ipv4.tcp_wmem" = "4096 65536 16777216";
+
+    # IPv6 forwarding for Tailscale exit node capability
+    "net.ipv6.conf.all.forwarding" = true;
+  };
+
+  # PAM limits
+  security.pam.loginLimits = [
+    {
+      domain = "*";
+      type = "soft";
+      item = "nofile";
+      value = "65536";
+    }
+    {
+      domain = "*";
+      type = "hard";
+      item = "nofile";
+      value = "65536";
+    }
+  ];
+
+  # Disable unnecessary services for a headless server
+  services.xserver.enable = false;
+  services.printing.enable = false;
+  services.pulseaudio.enable = false;
+
+  # Enable useful services
+  services.nscd.enable = true;
+  services.dbus.enable = true;
+
+  # Tailscale for secure access with SSH
+  services.tailscale = {
+    enable = true;
+    authKeyFile = "/etc/tailscale/authkey";
+    extraUpFlags = [
+      "--ssh"                    # Enable Tailscale SSH
+      "--accept-routes"          # Accept routes from other nodes
+      "--accept-dns=false"       # Don't override DNS (use system DNS)
+      "--advertise-exit-node"    # Allow other devices to use this as exit node
+    ];
+  };
+
+  # Allow Tailscale traffic through firewall
+  networking.firewall = {
+    trustedInterfaces = [ "tailscale0" ];
+    allowedUDPPorts = [ config.services.tailscale.port ];
+  };
+
+  # This value determines the NixOS release
+  system.stateVersion = "25.05";
+}

--- a/lib/mksystem.nix
+++ b/lib/mksystem.nix
@@ -37,6 +37,9 @@ let
 in systemFunc rec {
   inherit system;
 
+  # Pass inputs via specialArgs so they're available in imports without recursion
+  specialArgs = { inherit inputs; };
+
   modules = [
     # Apply our overlays. Overlays are keyed by system type so we have
     # to go through and apply our system type. We do this first so

--- a/modules/microvm/base.nix
+++ b/modules/microvm/base.nix
@@ -1,0 +1,225 @@
+# MicroVM base configuration function
+#
+# Creates a reusable VM configuration with common settings for Claude Code development.
+# Based on https://michael.stapelberg.ch/posts/2026-02-01-coding-agent-microvm-nix/
+#
+# This is a function that takes parameters and returns a NixOS module.
+# The module receives pkgs, lib, and inputs through the standard module arguments.
+#
+# Usage in loom-microvms.nix:
+#   microvm.vms.myvm = {
+#     autostart = false;
+#     config = (import ../modules/microvm/base.nix {
+#       hostName = "myvm";
+#       ipAddress = "192.168.83.2/24";
+#       tapId = "01";
+#       mac = "02:00:00:00:00:01";
+#       workspace = "/home/joost/microvm/myvm";
+#     });
+#   };
+
+{ hostName
+, ipAddress
+, tapId
+, mac
+, workspace
+, vcpu ? 8
+, mem ? 4096
+, extraPackages ? []
+, gatewayAddress ? "192.168.83.1"
+, bridgeName ? "microbr"
+, hostUser ? "joost"
+}:
+
+# Return a NixOS module that receives pkgs, lib, inputs via _module.args
+{ pkgs, lib, inputs, ... }:
+
+let
+  # Import unstable nixpkgs for latest Claude Code
+  pkgs-unstable = import inputs.nixpkgs-unstable {
+    system = pkgs.stdenv.hostPlatform.system;
+    config.allowUnfree = true;
+  };
+in
+{
+  imports = [
+    inputs.microvm.nixosModules.microvm
+  ];
+
+  # VM hardware configuration
+  microvm = {
+    hypervisor = "cloud-hypervisor";
+    vcpu = vcpu;
+    mem = mem;
+
+    # Network interface - TAP device connected to bridge
+    interfaces = [{
+      type = "tap";
+      id = "vm-${tapId}";
+      inherit mac;
+    }];
+
+    # Shared directories via virtiofs
+    shares = [
+      # Read-only Nix store from host (huge efficiency gain)
+      {
+        tag = "ro-store";
+        source = "/nix/store";
+        mountPoint = "/nix/.ro-store";
+        proto = "virtiofs";
+      }
+      # Workspace directory for the agent
+      {
+        tag = "workspace";
+        source = workspace;
+        mountPoint = "/workspace";
+        proto = "virtiofs";
+      }
+      # SSH host keys (generated on host, persisted across VM restarts)
+      {
+        tag = "ssh-host-keys";
+        source = "${workspace}/ssh-host-keys";
+        mountPoint = "/etc/ssh/host-keys";
+        proto = "virtiofs";
+      }
+      # Claude credentials from host
+      {
+        tag = "claude-credentials";
+        source = "/home/${hostUser}/claude-microvm";
+        mountPoint = "/home/agent/.claude-host";
+        proto = "virtiofs";
+      }
+    ];
+
+    # Writable overlay for /var (8GB)
+    volumes = [{
+      image = "var.img";
+      mountPoint = "/var";
+      size = 8192;
+    }];
+  };
+
+  # Networking inside the VM
+  systemd.network.enable = true;
+  systemd.network.networks."20-lan" = {
+    matchConfig.Type = "ether";
+    networkConfig = {
+      Address = ipAddress;
+      Gateway = gatewayAddress;
+      DNS = [ "1.1.1.1" "8.8.8.8" ];
+    };
+  };
+
+  networking.hostName = hostName;
+
+  # Note: microvm.nix automatically handles the Nix store overlay when
+  # you specify shares with mountPoint = "/nix/.ro-store". No need to
+  # manually configure fileSystems."/nix/store".
+
+  # SSH configuration
+  services.openssh = {
+    enable = true;
+    settings = {
+      PasswordAuthentication = false;
+      PermitRootLogin = "no";
+    };
+    # Use host keys from shared directory for persistence
+    hostKeys = [
+      { path = "/etc/ssh/host-keys/ssh_host_ed25519_key"; type = "ed25519"; }
+    ];
+  };
+
+  # Agent user for Claude Code
+  users.users.agent = {
+    isNormalUser = true;
+    home = "/home/agent";
+    extraGroups = [ "wheel" ];
+    # SSH keys are set up at runtime via setup-agent-ssh service
+  };
+
+  # Setup SSH authorized_keys at runtime from host-mounted file
+  systemd.services.setup-agent-ssh = {
+    description = "Setup SSH authorized_keys for agent user";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "local-fs.target" ];
+    before = [ "sshd.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      mkdir -p /home/agent/.ssh
+      if [ -f /etc/ssh/host-keys/authorized_keys ]; then
+        cp /etc/ssh/host-keys/authorized_keys /home/agent/.ssh/authorized_keys
+        chmod 600 /home/agent/.ssh/authorized_keys
+      fi
+      chown -R agent:users /home/agent/.ssh
+    '';
+  };
+
+  # Allow agent to sudo without password
+  security.sudo.wheelNeedsPassword = false;
+
+  # Link Claude credentials into agent home
+  systemd.services.setup-claude-credentials = {
+    description = "Setup Claude Code credentials for agent user";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "local-fs.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      mkdir -p /home/agent/.claude
+      if [ -f /home/agent/.claude-host/.claude.json ]; then
+        ln -sf /home/agent/.claude-host/.claude.json /home/agent/.claude/.claude.json
+      fi
+      if [ -f /home/agent/.claude-host/settings.json ]; then
+        ln -sf /home/agent/.claude-host/settings.json /home/agent/.claude/settings.json
+      fi
+      chown -R agent:users /home/agent/.claude
+    '';
+  };
+
+  # System packages
+  environment.systemPackages = with pkgs; [
+    # Development essentials
+    git
+    gnumake
+    gcc
+
+    # Editors
+    neovim
+
+    # Utilities
+    htop
+    ripgrep
+    fd
+    jq
+    tree
+    curl
+    wget
+
+    # Claude Code from unstable
+    pkgs-unstable.claude-code
+  ] ++ extraPackages;
+
+  # Nix configuration
+  nix = {
+    package = pkgs.nixVersions.latest;
+    extraOptions = ''
+      experimental-features = nix-command flakes
+    '';
+  };
+
+  # Timezone
+  time.timeZone = "UTC";
+
+  # Locale
+  i18n.defaultLocale = "en_US.UTF-8";
+
+  # Note: nixpkgs.config.allowUnfree is inherited from the host's configuration
+  # when the VM is built via microvm.nix module system.
+
+  system.stateVersion = "25.05";
+}

--- a/modules/microvm/host.nix
+++ b/modules/microvm/host.nix
@@ -1,0 +1,85 @@
+# MicroVM host configuration module
+#
+# Sets up network bridge with NAT for MicroVMs to access the internet.
+# Based on https://michael.stapelberg.ch/posts/2026-02-01-coding-agent-microvm-nix/
+#
+# Usage:
+#   services.microvmHost = {
+#     enable = true;
+#     externalInterface = "enp1s0";
+#   };
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.microvmHost;
+in
+{
+  options.services.microvmHost = {
+    enable = mkEnableOption "MicroVM host support with network bridge";
+
+    bridgeName = mkOption {
+      type = types.str;
+      default = "microbr";
+      description = "Name of the network bridge for MicroVMs";
+    };
+
+    bridgeAddress = mkOption {
+      type = types.str;
+      default = "192.168.83.1/24";
+      description = "IP address and prefix length for the bridge interface";
+    };
+
+    externalInterface = mkOption {
+      type = types.str;
+      description = "External network interface for NAT (e.g., enp1s0)";
+      example = "enp1s0";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Use systemd-networkd for network configuration
+    systemd.network.enable = true;
+
+    # Create the bridge device
+    systemd.network.netdevs."10-${cfg.bridgeName}" = {
+      netdevConfig = {
+        Kind = "bridge";
+        Name = cfg.bridgeName;
+      };
+    };
+
+    # Configure the bridge with static IP
+    systemd.network.networks."10-${cfg.bridgeName}" = {
+      matchConfig.Name = cfg.bridgeName;
+      networkConfig = {
+        Address = cfg.bridgeAddress;
+        DHCPServer = false;
+      };
+      linkConfig.RequiredForOnline = "no";
+    };
+
+    # Assign TAP interfaces (vm-*) to the bridge
+    systemd.network.networks."11-microvm-tap" = {
+      matchConfig.Name = "vm-*";
+      networkConfig.Bridge = cfg.bridgeName;
+    };
+
+    # Enable NAT for MicroVMs to access internet
+    networking.nat = {
+      enable = true;
+      internalInterfaces = [ cfg.bridgeName ];
+      externalInterface = cfg.externalInterface;
+    };
+
+    # Trust the bridge interface in the firewall
+    networking.firewall.trustedInterfaces = [ cfg.bridgeName ];
+
+    # Ensure IP forwarding is enabled (required for NAT)
+    boot.kernel.sysctl = {
+      "net.ipv4.ip_forward" = 1;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Add microvm.nix support for running isolated VMs for coding agents (Claude Code).

## Changes

- modules/microvm/host.nix - Network bridge with NAT
- modules/microvm/base.nix - Reusable VM config function
- hosts/loom.nix - Hetzner server with microvm host
- hosts/loom-microvms.nix - VM definitions
- README.md - Setup instructions

Generated with Claude Code