### PR TITLE
[codex] add codexbar cask and auto-start zellij on SSH

### DIFF
--- a/users/joost/darwin.nix
+++ b/users/joost/darwin.nix
@@ -46,6 +46,7 @@ let
     "cleanshot"
     "cmux"
     "codex-app" # OpenAI Codex desktop app
+    "codexbar" # steipete/tap - Codex menu bar app
     "companion" # Bitfocus companion, Streamdeck extension and emulation software
     "datagrip"
     "dataspell"
@@ -158,6 +159,7 @@ in
       "bearcove/tap"
       "dicklesworthstone/tap"
       "manaflow-ai/cmux"
+      "steipete/tap"
       "workos/tap"
     ];
     brews = [

--- a/users/joost/home-manager-server.nix
+++ b/users/joost/home-manager-server.nix
@@ -584,6 +584,12 @@ in {
 
       alias cd = __zoxide_z
       alias cdi = __zoxide_zi
+
+      # Auto-start zellij on SSH login (attach to existing session or create new)
+      if 'ZELLIJ' not-in ($env | columns) and 'SSH_TTY' in ($env | columns) {
+        zellij attach -c
+        exit
+      }
     '';
   };
 


### PR DESCRIPTION
## Summary

Two changes for the macOS/server setup:

1. **Add CodexBar homebrew cask** — Adds `steipete/tap` and installs `codexbar` (Codex menu bar app) on all non-minimal macOS machines.

2. **Auto-start zellij on SSH login to loom** — When SSH-ing into loom (or any server using `home-manager-server.nix`), nushell now auto-starts zellij with `attach -c` (reattach to existing session or create new). Gated on `SSH_TTY` (only interactive SSH) and `ZELLIJ` not already set (prevents nesting).
