### PR TITLE
[codex] bump codex 0.130.0 + caam 0.1.11, add update-overlays skill

### DIFF
--- a/Plans/now-create-a-skill-validated-cocke.md
+++ b/Plans/now-create-a-skill-validated-cocke.md
@@ -1,0 +1,142 @@
+# Plan: `update-overlays` skill
+
+## Context
+
+Every few weeks the third-party tools we vendor in `lib/overlays.nix` (codex, the Dicklesworthstone Rust CLIs, grepai, gemini-cli, gws, agent-browser, vercel-labs/agent-browser, etc.) release new versions. Right now bumping one of them is a manual ritual: read the overlay block, look up the latest version on GitHub or npm, `nix-prefetch-url` for each platform, edit the version + N hashes in `lib/overlays.nix`, then `make test` to validate. That's exactly what we just did for codex 0.114.0 → 0.130.0.
+
+We have ~25 overlay packages with the same shape (one `<name>Version` string + a `<name>Sources` attrset of per-platform `{url, sha256}`), so the work is mechanical and well-suited to a skill.
+
+This skill automates that exact flow for the "easy" packages (single-version + per-platform hash pattern), validates with `make test NIXNAME=loom`, and reports a diff for the user to commit. The fragile build-from-source packages (`ubs`, `cm`, `cco`, `ironclaw`) are out of scope.
+
+## Skill location
+
+```
+/home/joost/nixos-config/skills/update-overlays/SKILL.md
+```
+
+The existing `skills/workos` is a symlink into `~/.agents/skills/workos`. To make this skill discoverable system-wide, the user can add a reverse symlink later:
+```
+ln -s /home/joost/nixos-config/skills/update-overlays ~/.agents/skills/update-overlays
+```
+Creating that symlink is **not** part of the skill — the plan only adds the in-repo file. The user can wire up discovery themselves.
+
+## Package catalog (in scope)
+
+Source: `/home/joost/nixos-config/lib/overlays.nix`. All use the `<name>Version` + `<name>Sources` pattern, one fetchurl per platform.
+
+| Package | Line | Source | Repo / npm pkg | Platforms |
+|---|---|---|---|---|
+| grepai | 20–40 | gh-release | yoanbernabeu/grepai | 4 |
+| bv (beads-viewer) | 42–62 | gh-release | Dicklesworthstone/beads_viewer | 4 |
+| cass | 64–80 | gh-release | Dicklesworthstone/coding_agent_session_search | 3 |
+| slb | 83–102 | gh-release | Dicklesworthstone/slb | 4 |
+| csctf | 104–124 | gh-release | Dicklesworthstone/chat_shared_conversation_to_file | 4 |
+| brenner | 126–146 | gh-release | Dicklesworthstone/brenner_bot | 4 |
+| toon | 148–168 | gh-release | Dicklesworthstone/toon_rust | 4 |
+| ms | 170–182 | gh-release | Dicklesworthstone/meta_skill | 2 |
+| gws | 184–208 | gh-release | googleworkspace/cli | 4 |
+| br (beads_rust) | 210–230 | gh-release | Dicklesworthstone/beads_rust | 4 |
+| ntm | 232–252 | gh-release | Dicklesworthstone/ntm | 4 |
+| dcg | 254–274 | gh-release | Dicklesworthstone/destructive_command_guard | 4 |
+| caam | 276–296 | gh-release | Dicklesworthstone/coding_agent_account_manager | 4 |
+| agent-browser | 298–318 | gh-release | vercel-labs/agent-browser | 4 |
+| pi | 320–332 | gh-release | Dicklesworthstone/pi_agent_rust | 2 |
+| xf | 334–350 | gh-release | Dicklesworthstone/xf | 3 |
+| mcp-agent-mail | 352–364 | gh-release | Dicklesworthstone/mcp_agent_mail_rust | 2 |
+| fsfs (frankensearch) | 366–378 | gh-release | Dicklesworthstone/frankensearch | 2 |
+| casr | 380–392 | gh-release | Dicklesworthstone/cross_agent_session_resumer | 2 |
+| s2p | 394–414 | gh-release (bare binary) | Dicklesworthstone/source_to_prompt_tui | 4 |
+| pt | 416–424 | gh-release | Dicklesworthstone/process_triage | 1 |
+| rch | 426–434 | gh-release | Dicklesworthstone/remote_compilation_helper | 1 |
+| ru | ~886 | gh-release (bare binary) | Dicklesworthstone/repo_updater | varies |
+| codex | 1382–1436 | npm | @openai/codex | 4 |
+| gemini-cli | 1438–1465 | gh-release (JS bundle) | google-gemini/gemini-cli | 1 |
+
+**Out of scope (build-from-source / multi-file):** `ubs` (~90 module-file hashes per version), `cm` (cargoHash), `cco`, `ironclaw` (vendorHash). The skill should refuse these with a clear message: "build-from-source packages must be bumped manually."
+
+## How the skill works
+
+The skill is prose + commands the agent runs, modeled on `~/.agents/skills/deploy-servers/SKILL.md`. No new scripts/binaries — it instructs Claude to:
+
+### 1. Parse a target list
+- No args → update all in-scope packages.
+- Args = space-separated package names (`codex grepai bv`) → update only those.
+- Reject any name in the out-of-scope list with the manual-bump message.
+
+### 2. For each target, discover latest version
+- **npm** (codex only): `curl -s https://registry.npmjs.org/@openai/codex/latest | jq -r .version`
+- **gh-release** (everything else): `curl -s https://api.github.com/repos/<owner>/<repo>/releases/latest | jq -r .tag_name` then strip leading `v` if present.
+
+Compare against the current `<name>Version` string in `lib/overlays.nix`. If equal, skip and report "up to date". Otherwise continue.
+
+### 3. Compute new hashes
+For each platform entry in the package's `<name>Sources` attrset:
+1. Substitute the new version into the existing URL template.
+2. `curl -sIL -o /dev/null -w "%{http_code}" "$url"` — abort the package's update if any URL returns non-200 (upstream may have changed the asset naming).
+3. Fetch the hash:
+   - **SRI format** (codex, e.g. `sha256-...=`): `nix-prefetch-url --type sha256 "$url"` then `nix hash convert --hash-algo sha256 --to-sri sha256:<raw>`.
+   - **Legacy base32** (most packages, e.g. `0kk6lxc...`): `nix-prefetch-url --type sha256 "$url"` and use the raw output.
+   - **Hex** (e.g. slb `9ceed8af...`): `nix-prefetch-url --type sha256 "$url"` then `nix hash convert --hash-algo sha256 --to-base16 sha256:<raw>`.
+
+   Detect the current format by inspecting the existing hash string in the file (starts with `sha256-` → SRI; 64 hex chars → hex; else legacy base32). Preserve format → minimal diff.
+
+### 4. Edit `lib/overlays.nix`
+Use the `Edit` tool to change:
+- `<name>Version = "OLD";` → `<name>Version = "NEW";`
+- Each platform's `sha256 = "OLD";` (or `hash = "OLD";` for codex) → new value.
+
+One block per package, exact-string replacements so diffs are minimal.
+
+### 5. Validate
+- `make test NIXNAME=loom` once at the end (after all bumps) — single build covers every changed package because they're all in one overlay.
+- If `make test` fails, report which package(s) were just bumped and surface the build error. Do not auto-revert.
+
+### 6. Report
+Print a table:
+```
+package        old      → new      status
+codex          0.114.0  → 0.130.0  built ok
+grepai         0.35.0   → 0.36.0   built ok
+bv             0.15.2   → 0.15.2   up to date
+xf             0.2.0    → 0.3.0    URL 404 — skipped
+```
+Leave the working tree dirty. Do **not** commit (per user choice).
+
+## Critical files
+
+- **New:** `/home/joost/nixos-config/skills/update-overlays/SKILL.md` — the skill itself, ~150–200 lines of frontmatter + prose modeled on `deploy-servers/SKILL.md`.
+- **Read-only reference (in-skill):** `lib/overlays.nix` — the skill instructs Claude to grep/read this for the target package's block.
+- **Validation command:** `make test NIXNAME=loom` — from this repo's `Makefile`.
+
+## Frontmatter shape
+
+```yaml
+---
+name: update-overlays
+description: >
+  Bump third-party packages in lib/overlays.nix (codex, the Dicklesworthstone
+  Rust CLIs, grepai, gemini-cli, agent-browser, gws, …) to their latest
+  upstream version, refresh sha256 hashes for every platform, and validate
+  with `make test NIXNAME=loom`. Use when the user says "update overlays",
+  "bump codex", "update <pkg> to latest", "refresh tool versions", "update
+  dicklesworthstone tools", or "update all the AI tools". Skip ubs, cm, cco,
+  ironclaw — those are build-from-source and must be bumped manually.
+---
+```
+
+## Existing patterns reused
+
+- **Skill format / frontmatter / inventory table style:** `~/.agents/skills/deploy-servers/SKILL.md` is the model.
+- **Per-platform `<name>Sources` attrset:** used by every in-scope package in `lib/overlays.nix` (lines 20–434, plus codex 1382–1436). The skill leans on this consistency — same shape means one editing recipe works for all.
+- **Hash prefetch + format conversion:** `nix-prefetch-url` + `nix hash convert` (built-in to nix 2.x, no extra deps). This is the same approach used manually for the codex bump.
+- **Validation:** `make test NIXNAME=loom` — already the documented test command in `CLAUDE.md`. No new tooling.
+
+## Verification (after creating the skill file)
+
+1. **File exists and parses:** `cat /home/joost/nixos-config/skills/update-overlays/SKILL.md | head -20` — confirm YAML frontmatter renders cleanly.
+2. **Discoverable (optional):** if the user adds `ln -s /home/joost/nixos-config/skills/update-overlays ~/.agents/skills/update-overlays`, the skill should appear in the available-skills list on next Claude Code session start.
+3. **Smoke test (manual, after approval):** run the skill against a known-stale package. We just bumped `codex` so it's now current — pick another like `gemini-cli` or `bv` and ask the skill to bump it. Expect: latest version detected, hash fetched, file edited, `make test NIXNAME=loom` green, a one-row report.
+4. **Failure mode test:** ask the skill to bump `ubs` — expect refusal with the manual-bump message and no file changes.
+5. **No-op test:** re-run the skill on a just-bumped package — expect "up to date" status, zero file edits.
+
+Once the skill works on a single package, the broader workflow (`update-overlays` with no args → walk the whole list) is just iteration, no extra logic.

--- a/Plans/simplify-build-from-source-overlays.md
+++ b/Plans/simplify-build-from-source-overlays.md
@@ -1,0 +1,149 @@
+# Plan: Simplify build-from-source overlays (ubs, cm)
+
+> **Status:** queued — do after committing/pushing the current codex bump + `update-overlays` skill.
+
+## Context
+
+While building the `update-overlays` skill (see `Plans/now-create-a-skill-validated-cocke.md`), we marked four packages as out-of-scope because they build from source with multi-hash structures: `ubs`, `cm`, `cco`, `ironclaw`. Re-checking upstream as of 2026-05-12 showed that **two of them now publish proper GitHub releases** that would let us drop the build-from-source plumbing and bring them into the skill's scope.
+
+This plan captures both cleanups so they can be done independently of the skill landing.
+
+## Findings (2026-05-12)
+
+| Package | Currently | Upstream now | Switch? |
+|---|---|---|---|
+| **ubs** | v5.0.6, fetches ~90 module files from `raw.githubusercontent.com/.../v5.0.6/modules/*` | **v5.2.75** ships a single self-contained `ubs` bash script (125 KB) as a release asset | Yes — easy win |
+| **cm** (cass-memory) | v0.2.3, builds from source with `bun` + a fixed-output `bunDeps` derivation. Linux-only. Comment says "Pre-built GitHub release binaries are broken" | **v0.2.9** publishes per-platform binaries: `cass-memory-linux-x64` (144 MB), `cass-memory-macos-arm64` (106 MB), `cass-memory-macos-x64` (111 MB) — sizes consistent with embedded JS, suggesting the old breakage is fixed | Yes — needs a smoke test first |
+| `cco` (nikvdp/cco) | build-from-source | No releases | No, stay as-is |
+| `ironclaw` (nearai/ironclaw) | build-from-source v0.18.0 | v0.28.1 has full per-platform release tarballs | Out of scope for this plan (not Dicklesworthstone), but worth a separate task |
+
+## Task 1 — ubs: switch to single-binary release
+
+**Current block:** `lib/overlays.nix` lines ~499–590 (the `ubs` definition with the `ubsModules` attrset and the module-stitching `installPhase`).
+
+**Replace with** a standard gh-release pattern (one `ubsVersion`, one `ubsSources` attrset). The asset is a single bash script named `ubs` that works on all platforms, so the four platform keys can all point at the same URL:
+
+```nix
+ubsVersion = "5.2.75";
+ubsSources = {
+  "x86_64-linux" = {
+    url = "https://github.com/Dicklesworthstone/ultimate_bug_scanner/releases/download/v${ubsVersion}/ubs";
+    sha256 = "<prefetch>";
+  };
+  "aarch64-linux"  = { /* same URL, same sha256 */ };
+  "x86_64-darwin"  = { /* same URL, same sha256 */ };
+  "aarch64-darwin" = { /* same URL, same sha256 */ };
+};
+```
+
+Derivation shape (matches `csctf` at lines 104–124, which is also a bare-binary release):
+
+```nix
+ubs = prev.stdenv.mkDerivation {
+  pname = "ubs";
+  version = ubsVersion;
+  src = prev.fetchurl { url = ubsSource.url; sha256 = ubsSource.sha256; };
+  dontUnpack = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src $out/bin/ubs
+    chmod +x $out/bin/ubs
+  '';
+  meta = with prev.lib; {
+    description = "Ultimate Bug Scanner — pre-commit static analysis for AI coding workflows";
+    homepage = "https://github.com/Dicklesworthstone/ultimate_bug_scanner";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+};
+```
+
+**Hash:** one `nix-prefetch-url` call for the single asset URL, since the binary is identical across platforms.
+
+**Steps:**
+1. Confirm asset is genuinely platform-independent: `curl -sL .../v5.2.75/ubs | head -1` should be `#!/usr/bin/env bash` (already verified).
+2. Prefetch: `nix-prefetch-url --type sha256 https://github.com/Dicklesworthstone/ultimate_bug_scanner/releases/download/v5.2.75/ubs` → use in legacy base32 format to match neighbouring packages.
+3. Replace `lib/overlays.nix:499–590` with the simplified block above.
+4. Remove the `ubsBaseUrl` / `ubsModules` plumbing entirely.
+5. `make test NIXNAME=loom` to validate.
+6. Verify the binary works: `result/bin/ubs --version` (or whatever flag prints version).
+7. Update `skills/update-overlays/SKILL.md`:
+   - Remove `ubs` from the out-of-scope refusal list.
+   - Add `ubs` to the in-scope table.
+
+**Expected diff:** drops ~90 lines, adds ~25.
+
+## Task 2 — cm (cass-memory): test prebuilt binaries, switch if they work
+
+**Current block:** `lib/overlays.nix` lines ~954–1007 (the `cass-memory` `mkDerivation` with `bunDeps` and on-build `bun build src/cm.ts --compile`).
+
+**Problem to verify first:** the existing comment says
+
+> "Pre-built GitHub release binaries are broken (bun cross-compilation doesn't embed scripts)."
+
+That comment is from v0.2.3. v0.2.9 binaries are 100–160 MB, which is consistent with a fully-embedded bun bundle (bun's standalone compile produces a single fat binary). The old breakage may have been fixed.
+
+**Smoke-test the prebuilt before refactoring:**
+```bash
+mkdir -p /tmp/cm-test && cd /tmp/cm-test
+curl -sL https://github.com/Dicklesworthstone/cass_memory_system/releases/download/v0.2.9/cass-memory-linux-x64 -o cm
+chmod +x cm
+./cm --help          # or ./cm version
+./cm <some command>  # exercise an actual memory op
+```
+
+If it runs and produces sane output, switch the overlay. If not, leave as-is and bump the existing from-source build to v0.2.9 (update the `rev`, `hash`, and `bunDeps.outputHash`).
+
+**Switch-path replacement** (assuming binaries work):
+
+```nix
+cassMemoryVersion = "0.2.9";
+cassMemorySources = {
+  "x86_64-linux" = {
+    url = "https://github.com/Dicklesworthstone/cass_memory_system/releases/download/v${cassMemoryVersion}/cass-memory-linux-x64";
+    sha256 = "<prefetch>";
+  };
+  "x86_64-darwin" = {
+    url = "https://github.com/Dicklesworthstone/cass_memory_system/releases/download/v${cassMemoryVersion}/cass-memory-macos-x64";
+    sha256 = "<prefetch>";
+  };
+  "aarch64-darwin" = {
+    url = "https://github.com/Dicklesworthstone/cass_memory_system/releases/download/v${cassMemoryVersion}/cass-memory-macos-arm64";
+    sha256 = "<prefetch>";
+  };
+  # no aarch64-linux asset upstream
+};
+```
+
+Derivation: bare binary, same shape as the `csctf` / proposed `ubs` block. Critically — **keep `dontStrip = true; dontPatchELF = true;`** because bun standalone binaries embed JS after the ELF section and Nix's default strip/patchelf will destroy it (the current code already does this).
+
+**Steps:**
+1. Run the smoke test above. **If it fails, abort this task** — just bump the existing from-source build to v0.2.9 instead (update `rev` and refetch `hash` + `bunDeps.outputHash`).
+2. If smoke test passes:
+   a. Prefetch hashes for the three platform binaries.
+   b. Replace lines ~954–1007 with the simplified block.
+   c. Drop the `bunDeps` derivation and its fixed-output hash.
+   d. Expand `platforms` in `meta` to include the two macOS systems.
+3. `make test NIXNAME=loom`.
+4. Verify binary works as before: `result/bin/cm <command>`.
+5. Update `skills/update-overlays/SKILL.md`:
+   - Remove `cm` from the out-of-scope refusal list.
+   - Add `cm` to the in-scope table.
+
+**Expected diff:** drops ~30 lines of `bunDeps` plumbing, adds platform support for macOS, lifts the Linux-only restriction.
+
+## Critical files
+
+- **Modified:** `/home/joost/nixos-config/lib/overlays.nix` (ubs block ~499–590, cm block ~954–1007)
+- **Modified:** `/home/joost/nixos-config/skills/update-overlays/SKILL.md` — update out-of-scope and in-scope tables
+
+## Verification (both tasks combined)
+
+1. `make test NIXNAME=loom` — green build with both packages on the new pattern.
+2. `nix build --no-link --print-out-paths .#nixosConfigurations.loom.config.system.build.toplevel` then locate `ubs` and `cm` in `/nix/store/*`, run `--version` / `--help` on each — should produce real output, not a corrupted bun binary error.
+3. Re-run the `update-overlays` skill (no args) — `ubs` and `cm` should now appear in its in-scope table and either say "up to date" or get bumped if newer releases exist.
+
+## Out of this plan
+
+- `cco` (nikvdp/cco) — no upstream releases. Stay build-from-source.
+- `ironclaw` (nearai/ironclaw) — has releases (v0.28.1) but not Dicklesworthstone. Track separately if we want to simplify it.

--- a/lib/overlays.nix
+++ b/lib/overlays.nix
@@ -274,23 +274,23 @@
           dcgSource = dcgSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for dcg: ${prev.stdenv.hostPlatform.system}");
 
           # caam - coding agent account manager (instant auth switching)
-          caamVersion = "0.1.10";
+          caamVersion = "0.1.11";
           caamSources = {
             "x86_64-linux" = {
               url = "https://github.com/Dicklesworthstone/coding_agent_account_manager/releases/download/v${caamVersion}/caam_${caamVersion}_linux_amd64.tar.gz";
-              sha256 = "e84fa14fbed25fce02aa7a52c981a795ca424b06c3d73b616e30e6e712fa70c2";
+              sha256 = "e0a4e7e3e27c6b3e4f36f7e69ac23f3d59135702d713109de4a4431422a02845";
             };
             "aarch64-linux" = {
               url = "https://github.com/Dicklesworthstone/coding_agent_account_manager/releases/download/v${caamVersion}/caam_${caamVersion}_linux_arm64.tar.gz";
-              sha256 = "093fe1e648eb09f9350d422496a575868c5d8b0d065fe4df8185a248df10883a";
+              sha256 = "65e7808cd8d90e06ba10bb755f728ac55c4ff2c97f4bc50b7af8cf56b0e2f242";
             };
             "x86_64-darwin" = {
               url = "https://github.com/Dicklesworthstone/coding_agent_account_manager/releases/download/v${caamVersion}/caam_${caamVersion}_darwin_amd64.tar.gz";
-              sha256 = "06b1541607955c1cb4e8c83b006538f8055afdd7d6186fe5548ec5cf10641305";
+              sha256 = "dd89be148a8a9c4dd697df296403c00db302ed458fd93e89bcd83f452711478f";
             };
             "aarch64-darwin" = {
               url = "https://github.com/Dicklesworthstone/coding_agent_account_manager/releases/download/v${caamVersion}/caam_${caamVersion}_darwin_arm64.tar.gz";
-              sha256 = "386cf861872740611d42eba14b41cfe526a261552b6ae86e0d9095c635f2f519";
+              sha256 = "3863fb2ddfde51e4e6bded0498c933e0589487ae8a2211b216312840d242a205";
             };
           };
           caamSource = caamSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for caam: ${prev.stdenv.hostPlatform.system}");
@@ -1381,26 +1381,26 @@
 
           # codex - OpenAI coding agent CLI (pre-built binary from npm)
           codex = let
-            codexVersion = "0.114.0";
+            codexVersion = "0.130.0";
             codexSources = {
               "x86_64-linux" = {
                 url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexVersion}-linux-x64.tgz";
-                hash = "sha256-IAsvVZnT/HBwAsrGZhNQe5taFs2RVMffu7zbFwYLCL0=";
+                hash = "sha256-keEqVsSccCyGxcQoEc+j1RW21rwZbXC6nOolInMCqo8=";
                 vendorDir = "x86_64-unknown-linux-musl";
               };
               "aarch64-linux" = {
                 url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexVersion}-linux-arm64.tgz";
-                hash = "sha256-BbKaOAYkIVXpmQVF46yXg9Zmvz/ZKQkBmvjKd+JalX8=";
+                hash = "sha256-PyFyYKvoPG8P16g+BWy0U1N+Q1xnVM0zXs2TWCPY894=";
                 vendorDir = "aarch64-unknown-linux-musl";
               };
               "x86_64-darwin" = {
                 url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexVersion}-darwin-x64.tgz";
-                hash = "sha256-c8jsJrGeZPc5XvPGyt/AOYdauaVoZ5ST895Z3FdeSGk=";
+                hash = "sha256-IfFh/9efq4jFvZHkDRTIlP5tStYepOvIDU/PIBMJYMI=";
                 vendorDir = "x86_64-apple-darwin";
               };
               "aarch64-darwin" = {
                 url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexVersion}-darwin-arm64.tgz";
-                hash = "sha256-T9IVepFpw4jg6o3+1Cd41qQ173SnQ7kfwWcPOXcIeOo=";
+                hash = "sha256-9v7yzu6Jdwea07Mpa0wUwnB5NOa07Bqhoy1uUSGWsS0=";
                 vendorDir = "aarch64-apple-darwin";
               };
             };

--- a/skills/update-overlays/SKILL.md
+++ b/skills/update-overlays/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: update-overlays
+description: >
+  Bump third-party packages in lib/overlays.nix (codex, the Dicklesworthstone
+  Rust CLIs, grepai, gemini-cli, agent-browser, gws, ...) to their latest
+  upstream version, refresh sha256 hashes for every platform, and validate
+  with `make test NIXNAME=loom`. Use when the user says "update overlays",
+  "update overlay packages", "bump codex", "update <pkg> to latest", "refresh
+  tool versions", "update dicklesworthstone tools", "update all the AI tools",
+  or "check for new versions of our git tools". Skip ubs, cm, cco, ironclaw —
+  those are build-from-source and must be bumped manually.
+---
+
+# Update Overlays
+
+Bump third-party overlay packages in `lib/overlays.nix` to their latest upstream releases.
+
+## When to use
+
+Triggered by phrases like:
+- "update overlays" / "update overlay packages"
+- "update <pkg> to latest" (e.g. "update codex", "update bv", "bump gemini-cli")
+- "refresh tool versions" / "update the AI tools"
+- "update dicklesworthstone tools"
+- "check for new versions of our git tools"
+
+## In-scope packages
+
+All packages defined in `/home/joost/nixos-config/lib/overlays.nix` that follow the standard `<name>Version` + `<name>Sources` pattern (one `<name>Version` string and a per-platform attrset of `{url, sha256/hash}`).
+
+| Name | Source | Repo / npm pkg |
+|---|---|---|
+| grepai | gh-release | yoanbernabeu/grepai |
+| bv (beads-viewer) | gh-release | Dicklesworthstone/beads_viewer |
+| cass | gh-release | Dicklesworthstone/coding_agent_session_search |
+| slb | gh-release | Dicklesworthstone/slb |
+| csctf | gh-release | Dicklesworthstone/chat_shared_conversation_to_file |
+| brenner | gh-release | Dicklesworthstone/brenner_bot |
+| toon | gh-release | Dicklesworthstone/toon_rust |
+| ms | gh-release | Dicklesworthstone/meta_skill |
+| gws | gh-release | googleworkspace/cli |
+| br (beads_rust) | gh-release | Dicklesworthstone/beads_rust |
+| ntm | gh-release | Dicklesworthstone/ntm |
+| dcg | gh-release | Dicklesworthstone/destructive_command_guard |
+| caam | gh-release | Dicklesworthstone/coding_agent_account_manager |
+| agent-browser | gh-release | vercel-labs/agent-browser |
+| pi | gh-release | Dicklesworthstone/pi_agent_rust |
+| xf | gh-release | Dicklesworthstone/xf |
+| mcp-agent-mail | gh-release | Dicklesworthstone/mcp_agent_mail_rust |
+| fsfs (frankensearch) | gh-release | Dicklesworthstone/frankensearch |
+| casr | gh-release | Dicklesworthstone/cross_agent_session_resumer |
+| s2p | gh-release (bare binary) | Dicklesworthstone/source_to_prompt_tui |
+| pt | gh-release | Dicklesworthstone/process_triage |
+| rch | gh-release | Dicklesworthstone/remote_compilation_helper |
+| ru | gh-release (bare binary) | Dicklesworthstone/repo_updater |
+| codex | npm | @openai/codex |
+| gemini-cli | gh-release (JS bundle) | google-gemini/gemini-cli |
+
+## Out of scope — refuse with message
+
+`ubs`, `cm`, `cco`, `ironclaw` build from source and have multi-hash structures (per-file module hashes, cargoHash, vendorHash). If asked to bump any of these, reply:
+
+> "<pkg> is build-from-source and must be bumped manually. See `lib/overlays.nix` for its hash structure."
+
+Do not edit anything for these packages.
+
+## Workflow
+
+### 1. Parse target list
+
+- No package names mentioned → update all in-scope packages.
+- Package names mentioned (e.g. "update codex and bv") → update only those.
+- Any out-of-scope name → refuse with the message above and skip it.
+
+### 2. For each target, discover latest version
+
+**npm** (codex only):
+```bash
+curl -s https://registry.npmjs.org/@openai/codex/latest | jq -r .version
+```
+
+**gh-release** (everything else):
+```bash
+curl -s "https://api.github.com/repos/<owner>/<repo>/releases/latest" | jq -r .tag_name | sed 's/^v//'
+```
+
+If the request rate-limits (HTTP 403 from api.github.com), retry once with `gh release view --repo <owner>/<repo> --json tagName -q .tagName | sed 's/^v//'` (gh is in PATH on this machine).
+
+Read the current `<name>Version = "...";` from `lib/overlays.nix`. If it matches the latest, mark as **up to date** and skip.
+
+### 3. Fetch new hashes
+
+For each platform key in the package's `<name>Sources` attrset, substitute the new version into the existing URL template (just replace the version number in the URL string — every other part of the URL is unchanged).
+
+For each new URL:
+
+1. **Verify it exists:**
+   ```bash
+   code=$(curl -sIL -o /dev/null -w "%{http_code}" "$url")
+   ```
+   If non-200, abort this package's bump and report `URL HTTP <code> — skipped`. Do not delete the package's block.
+
+2. **Detect the hash format** in the *current* file for that entry:
+   - Starts with `sha256-` and ends with `=` → **SRI**
+   - 64 hex chars (`[0-9a-f]{64}`) → **hex**
+   - Otherwise (e.g. `0kk6lxc...`) → **legacy base32**
+
+3. **Compute new hash in that same format:**
+   ```bash
+   raw=$(nix-prefetch-url --type sha256 "$url")                       # legacy base32 (nix32)
+   sri=$(nix hash convert --hash-algo sha256 --to sri    "sha256:$raw")
+   hex=$(nix hash convert --hash-algo sha256 --to base16 "sha256:$raw")
+   ```
+   `nix hash convert` uses `--to <format>` with a space (the format names are `sri`, `base16`, `nix32`, `base64`). Do **not** write `--to-sri` or `--to-base16` — those are not valid flags on Nix 2.33+ and the command silently fails with an empty hash. Pick the variant matching the current format.
+
+   - codex uses SRI `hash = "sha256-...";`
+   - Most packages use legacy base32 `sha256 = "0xxx...";`
+   - slb uses hex `sha256 = "9cee...";`
+
+   **Preserve the exact existing format** — both the variable name (`sha256` vs `hash`) and the encoding. Goal: minimal diff.
+
+### 4. Edit `lib/overlays.nix`
+
+Use the `Edit` tool. For each package:
+
+- One edit for `<name>Version = "OLD";` → `<name>Version = "NEW";`
+- One edit per platform replacing the old hash string with the new one.
+
+Use exact-string replacements (the `old_string` parameter of `Edit`) — never `replace_all` (hashes can collide in theory; play it safe).
+
+Tip: when matching `<name>Version`, include enough surrounding context so the match is unique (e.g. the comment line above it). Same for hashes — include the URL line above each `sha256 = "...";` to disambiguate.
+
+### 5. Validate
+
+After **all** target packages are edited, run a single validation:
+
+```bash
+make test NIXNAME=loom
+```
+
+This builds `nixosConfigurations.loom` which pulls every overlay package on x86_64-linux. It will not exercise darwin/aarch64 builds, but those use the same fetchurl pattern — if the URL is valid and the hash matches what `nix-prefetch-url` returned, the build will succeed.
+
+If `make test` fails:
+- Surface the error to the user.
+- Identify which package's block contains the build failure (usually the error mentions a `/nix/store/.../codex-0.130.0.drv` or similar path).
+- **Do not auto-revert** — let the user inspect and decide.
+
+### 6. Report
+
+Print a Markdown table summarising every package the user asked about:
+
+```
+| package        | old     | new     | status        |
+|----------------|---------|---------|---------------|
+| codex          | 0.114.0 | 0.130.0 | built ok      |
+| grepai         | 0.35.0  | 0.36.0  | built ok      |
+| bv             | 0.15.2  | 0.15.2  | up to date    |
+| xf             | 0.2.0   | 0.3.0   | URL 404 (linux-arm64) — skipped |
+| ubs            | —       | —       | manual only   |
+```
+
+End with: "Working tree is dirty — review the diff and commit when ready." **Do not commit.**
+
+## Hash format quick reference
+
+For `lib/overlays.nix`, three formats are in use. Detect and preserve:
+
+| Format       | Looks like                                     | Convert command                                              |
+|--------------|------------------------------------------------|--------------------------------------------------------------|
+| SRI          | `sha256-keEqVsSccCyGxcQoEc+j1RW21rwZbXC6...=`  | `nix hash convert --hash-algo sha256 --to sri    sha256:$raw` |
+| hex          | `9ceed8af0ec18b425bafda9bb6b289e1e42faec...`   | `nix hash convert --hash-algo sha256 --to base16 sha256:$raw` |
+| legacy base32| `0kk6lxc904j3mxxjxp7df4hq9swib8rj5srqsqayk...` | use `$raw` from `nix-prefetch-url` directly                   |
+
+`$raw` = the stdout of `nix-prefetch-url --type sha256 <url>` (base32 SRI-unprefixed).
+
+## Inline-version edge case (`ru`, `gemini-cli`)
+
+Two in-scope packages **do not** have a `<name>Version = "...";` variable — the version is hardcoded directly inside the URL string and the derivation's `version = "...";` field:
+
+- `ru` (Dicklesworthstone/repo_updater, `lib/overlays.nix` ~line 886) — `releases/download/v1.2.1/ru` is literal.
+- `gemini-cli` (google-gemini/gemini-cli, ~line 1438) — `releases/download/v0.32.1/gemini.js` is literal.
+
+For these two, replace the version string everywhere it appears in the package's block (typically: once in the URL, once in `version = "...";`, sometimes once more in `homepage` if pinned). Use multiple targeted `Edit` calls — don't try to do this with `replace_all` on the whole file because the version digits may collide with other packages.
+
+## URL templating gotchas
+
+Some packages use distinct URL shapes across platforms — re-use the *existing* URL string verbatim and only substitute the version number. Examples already in the file:
+
+- `grepai`: `grepai_${version}_linux_amd64.tar.gz`
+- `cass`: `cass-linux-amd64.tar.gz` (no version in filename)
+- `csctf`: `csctf-linux-x64` (bare binary, no .tar)
+- `codex`: `codex-${version}-linux-x64.tgz` (npm registry)
+- `ubs` modules: `https://raw.githubusercontent.com/.../v${version}/modules/<file>` (out of scope, but noted)
+
+If upstream changes the asset naming between releases, the URL check in step 3.1 will fail and the package is skipped. Tell the user the asset name appears to have changed and let them update manually.
+
+## Examples
+
+**User:** "update codex to latest"
+→ Fetch npm latest, compare to current `codexVersion`, refresh 4 SRI hashes, edit, run `make test NIXNAME=loom`, report.
+
+**User:** "update overlays"
+→ Walk every in-scope package above, refresh anything stale, single `make test` at the end.
+
+**User:** "update ubs"
+→ Refuse: "ubs is build-from-source and must be bumped manually."
+
+**User:** "bump dicklesworthstone tools"
+→ Filter the in-scope table to repos with owner `Dicklesworthstone`, update those.
+
+## Notes
+
+- The skill never touches `flake.lock`. That's `make update`'s job.
+- The skill never commits or pushes — leave the diff for the user to review.
+- All hash math runs on the local machine. No network calls except `curl` to GitHub/npm and the `nix-prefetch-url` download.


### PR DESCRIPTION
## Summary

Three related changes for managing third-party packages in `lib/overlays.nix`:

1. **Bump `codex` 0.114.0 → 0.130.0** (OpenAI Codex CLI from the `@openai/codex` npm package). Refreshed SRI hash for all four platforms (linux x64/arm64, darwin x64/arm64). Tarball structure unchanged.

2. **Bump `caam` 0.1.10 → 0.1.11** (Dicklesworthstone/coding_agent_account_manager). Refreshed hex sha256 for all four platforms. Done by running the new skill against itself as a live test (see below).

3. **Add an `update-overlays` skill** at `skills/update-overlays/SKILL.md` that automates this kind of bump for ~25 in-scope packages (codex, the Dicklesworthstone Rust CLIs, grepai, gemini-cli, agent-browser, gws, …). Triggered by phrases like "update overlays", "update codex", "bump dicklesworthstone tools", etc.

## Why this is useful

Bumping a third-party overlay package today is mechanical and tedious: read the overlay block, look up the latest version on GitHub/npm, run `nix-prefetch-url` for each platform, edit the version + N hashes in `lib/overlays.nix`, run `make test NIXNAME=loom`. The skill codifies the recipe so future bumps are one prompt instead of a 15-minute manual exercise per package.

## What the skill does

- Parses targets (no args → all in-scope packages; explicit args → just those).
- Refuses out-of-scope packages (`ubs`, `cm`, `cco`, `ironclaw`) with a clear "build-from-source, must be bumped manually" message — see follow-up plan below.
- For each target: hits npm registry or GitHub Releases API for the latest version, verifies each platform URL with HEAD requests, fetches new hashes via `nix-prefetch-url` and preserves the existing hash format (SRI for `codex`, hex for `slb`/`caam`, legacy base32 for the rest).
- Edits `lib/overlays.nix` with surgical exact-string replacements (no `replace_all`).
- Runs `make test NIXNAME=loom` once at the end as a single combined validation.
- Reports a markdown summary table of old/new/status per package.
- Leaves the working tree dirty for the user to review — does not commit, by design.

## Live test results

Ran the skill end-to-end before merging. Two bugs surfaced and were fixed in this same PR:

1. **`nix hash convert` flag syntax** — first draft said `--to-base16` / `--to-sri`. On Nix 2.33+ the correct syntax is `--to base16` / `--to sri` (space-separated, `<format>` as a separate arg). The wrong syntax fails *silently* with empty output, which would write empty hash strings into the overlay. Now documented and the skill explicitly warns against the wrong form.

2. **Inline-version edge case** — two in-scope packages (`ru` and `gemini-cli`) hardcode the version directly in the URL string and `version = "...";` field rather than using a `<name>Version` variable like the other 23. Added a dedicated "Inline-version edge case" section instructing the agent to do per-occurrence replacements for these two.

Discovery phase output across all 25 in-scope packages (run in parallel, ~3 seconds total):

| Status | Count | Notes |
|---|---|---|
| up to date | 5 | codex, csctf, grepai, ms, s2p |
| stale | 20 | Most are minor/patch versions behind |

Live bump of `caam` 0.1.10 → 0.1.11 went through the full pipeline (URL HEAD checks → `nix-prefetch-url` → hex conversion → 5 surgical edits in `lib/overlays.nix` → `nix build` of the full loom system → binary runtime verification: `caam 0.1.11 (7c604c4)`). Diff was 1 version line + 4 hash lines, zero collateral changes.

The 19 other stale packages are intentionally not bumped in this PR — they're separate work and each upgrade carries its own risk surface. The skill handles them one at a time as needed.

## Skill location and discovery

The skill lives in this repo at `skills/update-overlays/SKILL.md`. To surface it system-wide, the user can add a symlink:

```
ln -s /home/joost/nixos-config/skills/update-overlays ~/.agents/skills/update-overlays
```

That symlink step is intentionally not part of this PR.

## Follow-up plan (queued, not in this PR)

While building the skill, I checked upstream for the four out-of-scope build-from-source packages. Two of them now publish proper GitHub releases that would let us drop the build-from-source plumbing entirely:

- **`ubs`** (currently fetches ~90 module shell files at a tagged path from `raw.githubusercontent.com`) now ships a single self-contained `ubs` bash script as a release asset at v5.2.75 (we're on v5.0.6). Switching saves ~90 lines of `ubsModules` plumbing.
- **`cm`** (cass-memory, currently a bun build-from-source with a fixed-output `bunDeps` derivation, Linux-only at v0.2.3) now publishes per-platform prebuilt binaries at v0.2.9. Sizes (~100–160 MB each) are consistent with a fully-embedded bun bundle, which suggests the old "binaries broken" complaint that motivated the from-source build has been fixed. Needs a smoke test before switching.

Captured in `Plans/simplify-build-from-source-overlays.md` to do after this lands. Once those two are simplified, they'd graduate into the skill's in-scope list as well.

`cco` and `ironclaw` stay build-from-source (no usable releases / different owner).

## Validation

- `nix build --no-link --print-out-paths .#nixosConfigurations.loom.config.system.build.toplevel` ✅ — builds the full loom system end-to-end including both `codex-0.130.0` and `caam-0.1.11`.
- `result/bin/codex --version` → `codex-cli 0.130.0` ✅
- `result/bin/caam version` → `caam 0.1.11 (7c604c4) built on 2026-04-25T01:00:46Z with go1.26.2` ✅
- Discovery phase output matches across local invocation and skill spec.

## Test plan

- [x] Run the skill against a known-stale package and confirm full bump cycle works (caam, done in this PR).
- [x] Re-run the skill against a just-bumped package and confirm "up to date" with zero file edits (codex, verified via discovery).
- [ ] After merge, ask the skill to bump `ubs` and confirm it refuses with the manual-bump message and touches no files.
- [ ] Tackle `Plans/simplify-build-from-source-overlays.md` to graduate `ubs` and `cm` into the skill's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
