### PR TITLE
[codex] hermes-agent: install on loom + add systemd unit

### DIFF
--- a/Plans/add-hermes-agent.md
+++ b/Plans/add-hermes-agent.md
@@ -1,104 +1,101 @@
-# Plan: Add hermes-agent to replace ironclaw + openclaw
+# Plan: Install hermes-agent on loom
 
-> **Status:** queued. The teardown of ironclaw and openclaw shipped first (see PR following `replace ironclaw with hermes-agent`). This plan covers the rebuild.
+> **Status:** in progress. Decisions locked: target host = loom (workstation), install method = upstream `install.sh`, credentials = reuse the values currently encrypted under `ironclaw-*` keys in `secrets/joostclaw.yaml`. Steps 1 and the Nix-side systemd unit are **done**; steps 2–4 are the user's manual follow-up.
 
 ## Context
 
-`ironclaw` (nearai/ironclaw) and `openclaw` (openclaw/nix-openclaw) were both removed from this repo in one commit because we're switching the personal AI assistant stack to **NousResearch/hermes-agent** (Python TUI agent, https://hermes-agent.nousresearch.com). hermes-agent doesn't map cleanly onto the old architecture, so it needs its own design rather than a drop-in overlay swap.
+We tore out `ironclaw` and `openclaw` from this repo (see commit `0b10c28` and PR #32) because we're switching the personal AI stack to **[NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)**. Initial assumption was that hermes would slot into joostclaw's old container service pattern. Investigation showed:
 
-After the teardown PR landed:
-- `joostclaw` (Hetzner Cloud server, 91.99.10.155) runs base NixOS + Tailscale + podman + auto-update only — no application stack.
-- All ironclaw/openclaw secrets (anthropic key, telegram tokens, gateway tokens, db password) remain encrypted in `secrets/joostclaw.yaml` as inert data. They can be recovered with `sops secrets/joostclaw.yaml` if their credentials are still useful for hermes-agent.
+- **No published container image** for hermes-agent (would mean building a complex multi-stage Dockerfile on-host)
+- **No PyPI package** (only GitHub source)
+- **No direct `ANTHROPIC_API_KEY` env var path** — providers are configured via interactive `hermes setup` writing to `~/.hermes/config.yaml`
+- **Hermes is single-user by design** — it's a personal TUI agent that grows with you, not a multi-tenant gateway
 
-## Decisions still open
+→ Architecture fits a **workstation install** better than a containerized server service. New target: **loom**.
 
-| Question | Options | Default if not decided |
-|---|---|---|
-| Where does hermes-agent run? | (a) joostclaw server, like ironclaw was; (b) per-user on workstations (loom, j7, j8…); (c) both | (a) — keeps joostclaw's existing role as the "remote AI box" |
-| Install method | (a) curl install.sh inside a systemd user service; (b) Nix overlay using uv2nix / buildPythonApplication; (c) container (podman) running upstream's Dockerfile | (c) — least Nix coupling, follows the openclaw OCI pattern, easiest to update |
-| Which Telegram bot to point at | Reuse the ironclaw or openclaw bot from sops; or register a new one | Reuse to avoid losing chat history |
-| LLM backend | Anthropic via existing api key; or Nous Portal; or OpenRouter | Anthropic — secret already exists, no new account |
+## Decisions
 
-Ask `joost` to pick before implementing.
-
-## Recommended approach (container on joostclaw)
-
-The hermes-agent repo ships a `Dockerfile`. Easiest path: run it as a podman container managed by a new `services.hermesAgentOci` module that mirrors the structure of the (deleted) `services.openclawOci`.
-
-### Files to create
-
-| Path | Purpose |
+| Question | Decision |
 |---|---|
-| `modules/hermes-agent-oci.nix` | NixOS module: declares `services.hermesAgentOci.instances.<name>` with `enable`, `uid`/`gid`, `subUidStart`/`subGidStart`, ports, secret file paths. Generates a `virtualisation.oci-containers.containers.hermes-agent-<name>` running upstream's image. Model on the deleted `modules/openclaw-oci.nix` (its history is in git for reference). |
-| `hosts/joostclaw.nix` (edit) | Re-add the module import, sops secret declarations (renamed `hermes-*`), and the `services.hermesAgentOci.instances.main` block. |
-| `secrets/joostclaw.yaml` (edit via `sops`) | Rename the inert `ironclaw-*` / `openclaw-*` entries to `hermes-*` or re-encrypt fresh values. |
-| `users/joost/home-manager-joostclaw.nix` (optional edit) | Add a wrapper script that opens an SSH connection to joostclaw and runs `hermes` over it, the way the OpenClaw `openclawGatewayExec` wrapper used to do. |
+| Target host | **loom** (workstation), not joostclaw |
+| Install method | **upstream `install.sh`** — uv + python venv + npm + playwright at `~/.hermes/` |
+| Bootstrap | manual on loom (no Nix automation in this phase) |
+| Credentials | **reuse** the encrypted `ironclaw-anthropic-api-key` and `ironclaw-telegram-bot-token` values from `secrets/joostclaw.yaml`; transfer them off joostclaw to loom's `~/.env.hermes` |
+| Sops setup on loom | **not needed** for this phase. loom is not in `.sops.yaml`; `~/.env.hermes` lives outside Nix |
 
-### Steps
+## What's already in place on loom
 
-1. **Pick container image source.** Either build it via `nix2container` from the upstream Dockerfile, or pull a published tag. Check `https://github.com/NousResearch/hermes-agent/pkgs/container` for a published image; if there isn't one, build locally:
+✅ `uv` 0.9.30 (via `users/joost/home-manager.nix`)
+✅ `node` and `npm` (via home-manager)
+✅ `~/.env` pattern is already established (ElevenLabs, Apify, HTTP bearer tokens live there)
+
+No Nix changes are required to start. The bootstrap is entirely upstream-driven.
+
+## Bootstrap steps (run on loom)
+
+1. **Install hermes.** ✅ **DONE** — run as part of this PR:
    ```bash
-   git clone https://github.com/NousResearch/hermes-agent.git /tmp/hermes
-   cd /tmp/hermes && podman build -t hermes-agent:v2026.5.7 .
+   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh \
+     | bash -s -- --skip-setup
    ```
+   Installed to:
+   - Code:   `~/.hermes/hermes-agent/` (uv venv)
+   - Config: `~/.hermes/config.yaml`
+   - Env:    `~/.hermes/.env` (template — fill in API keys at step 3)
+   - Data:   `~/.hermes/cron/`, `sessions/`, `logs/`
+   - Launcher: `~/.local/bin/hermes`
 
-2. **Write `modules/hermes-agent-oci.nix`.** Use the deleted `modules/openclaw-oci.nix` from git history as a template — its `slirp4netns` networking, uid mapping, sops-secret-mounting, and systemd hardening all apply identically. Adjust:
-   - Container image reference
-   - Environment variables hermes-agent expects (read its docs at https://hermes-agent.nousresearch.com/docs/)
-   - Port numbers (default to 3100 if nothing else is using it on joostclaw)
-   - Persistent volume path (`/var/lib/hermes-agent/<instance>` for the agent's SQLite memory store)
+   The Nix-managed systemd unit `hermes-agent-gateway` was added in `users/joost/home-manager-server.nix` (gated `lib.mkIf (isLinux && currentSystemName == "loom")`). After the next `nixos-rebuild switch`, the unit will exist but be disabled until you do step 4.
 
-3. **Wire it into joostclaw:**
-   ```nix
-   imports = [ ... ../modules/hermes-agent-oci.nix ];
-
-   sops.secrets.hermes-anthropic-api-key = { owner = "hermes-main"; group = "hermes-main"; mode = "0400"; };
-   sops.secrets.hermes-telegram-bot-token = { owner = "hermes-main"; group = "hermes-main"; mode = "0400"; };
-
-   services.hermesAgentOci.instances.main = {
-     enable = true;
-     uid = 3030;
-     gid = 3030;
-     subUidStart = 130300;
-     subGidStart = 130300;
-     httpPort = 3100;
-     anthropicKeyFile = config.sops.secrets.hermes-anthropic-api-key.path;
-     telegramTokenFile = config.sops.secrets.hermes-telegram-bot-token.path;
-   };
-   ```
-
-4. **Re-encrypt secrets.** Either:
+2. **Recover credentials from joostclaw.** The Anthropic key and Telegram bot token are still in `secrets/joostclaw.yaml`, encrypted to joostclaw's age key. To decrypt, run on joostclaw itself (since loom is not in `.sops.yaml`):
    ```bash
-   sops secrets/joostclaw.yaml
-   # in the editor: rename ironclaw-anthropic-api-key → hermes-anthropic-api-key,
-   #                rename ironclaw-telegram-bot-token → hermes-telegram-bot-token,
-   #                delete the rest of the ironclaw-* and openclaw-* entries.
+   ssh joost@joostclaw
+   cd ~/code/nixos-config   # or wherever the repo is cloned on joostclaw
+   sops -d secrets/joostclaw.yaml | grep -E "^ironclaw-(anthropic-api-key|telegram-bot-token):"
    ```
-   Or generate fresh credentials and replace them.
+   Copy the two plaintext values back to loom.
 
-5. **Validate locally:** `nix build .#nixosConfigurations.joostclaw.config.system.build.toplevel`.
-
-6. **Deploy:**
+3. **Provision env on loom** by editing the hermes-managed file in place:
    ```bash
-   make hetzner/copy NIXADDR=91.99.10.155 NIXUSER=joost
-   make hetzner/switch NIXADDR=91.99.10.155 NIXNAME=joostclaw
+   $EDITOR ~/.hermes/.env
    ```
-   Or commit, push to main, and wait for the 4 AM `nixosAutoUpdate` to apply.
+   Fill in (uncomment + paste values from step 2):
+   - `ANTHROPIC_API_KEY=...`
+   - `TELEGRAM_BOT_TOKEN=...`
+   - `TELEGRAM_ALLOWED_USERS=<your numeric telegram user id>`
 
-7. **Smoke-test on joostclaw:**
-   - `systemctl status podman-hermes-agent-main.service` — running, no restart loop
-   - `curl http://localhost:3100/health` (or whatever endpoint hermes exposes)
-   - Send a Telegram message to the bot — it should respond
+   The file is already a template hermes created at install time — has every provider's variables commented out with docs.
+
+4. **Configure providers + activate the gateway:**
+   ```bash
+   hermes setup                                             # interactive: pick Anthropic, set model
+   make switch NIXNAME=loom                                 # materializes the Nix-managed unit
+   systemctl --user daemon-reload
+   systemctl --user enable --now hermes-agent-gateway
+   systemctl --user status hermes-agent-gateway             # active (running)
+   ```
+
+5. **Smoke-test:**
+   - `hermes` — TUI starts, responds to "hi"
+   - Send a Telegram message to the bot → bot replies
+   - `journalctl --user -u hermes-agent-gateway -f` — no errors
+
+## Optional follow-ups (separate PRs)
+
+- **Add hermes to `update-overlays` skill scope.** Once a stable distribution channel exists (PyPI, github release tarball, or container image on GHCR), the skill can bump it automatically. For now hermes self-updates from inside (`hermes update`).
+- **Per-workstation expansion.** If you also want hermes on j7 / j8 / fu137, the systemd unit currently has `currentSystemName == "loom"` — widen that guard or move the block into a per-host file. They use `users/joost/home-manager.nix` (not `home-manager-server.nix`), so the unit needs to be duplicated there or factored into a shared module.
+- **Clean inert secrets.** The `ironclaw-*` and `openclaw-*` entries still live encrypted in `secrets/joostclaw.yaml`. They're inert (nothing references them in Nix) but bloat the file. To clean, run `sops secrets/joostclaw.yaml` on joostclaw and delete the unused keys.
 
 ## Out of scope
 
-- **Renaming `joostclaw`.** The hostname has "claw" in it from the openclaw era. Renaming a host touches many places (flake.nix, sops .sops.yaml, secrets/, auto-update flake target, Tailscale machine name). Leave as `joostclaw` unless explicitly asked to rename.
-- **Migrating ironclaw's database.** ironclaw stored data in a `postgres` instance on joostclaw. PostgreSQL was removed in the teardown. The data files on `/var/lib/postgresql/` on the server still exist on disk but are inaccessible. Nothing in hermes-agent needs that data. If the user wants it preserved long-term, take a manual `pg_dump` before this plan executes — once the postgres service is gone for a few weeks the data is effectively abandoned.
-- **Per-workstation hermes install.** This plan covers the server install. If the user wants `hermes` available on loom / j7 / j8 as a CLI, that's a separate change: either `home.packages` with a Nix derivation (uv2nix), or just running `curl ... install.sh` manually outside Nix.
+- **joostclaw rebuild.** The Hetzner box stays as it is — base NixOS + Tailscale + auto-update only. If we ever want hermes on a remote box again, that's a separate plan.
+- **uv2nix / nix-packaging hermes.** Hermes is exact-pinned across ~50 Python deps + npm workspace deps + Playwright browsers. Replicating its uv-lock + Playwright-install behavior in pure Nix is days of work for marginal benefit when `install.sh` already does it correctly.
+- **Renaming the `ironclaw-*` sops keys to `hermes-*`.** Only joostclaw can decrypt the file (its age key is the recipient). Renaming requires running `sops` on joostclaw itself. Not worth doing until we actually reference these secrets from Nix again.
 
-## Verification (post-implementation)
+## Verification (after bootstrap)
 
-1. `nix build .#nixosConfigurations.joostclaw.config.system.build.toplevel` green locally.
-2. After deploy: `ssh joost@joostclaw "systemctl status podman-hermes-agent-main"` shows `active (running)`.
-3. End-to-end: send a Telegram message to the hermes bot, get a response generated by Anthropic.
-4. The hermes-agent built-in skill registry initializes (logs should show a skill catalog being built on first start).
+1. `command -v hermes` returns a path under `~/.hermes/` or `~/.local/bin/`.
+2. `hermes version` reports `>= 0.13.0`.
+3. `hermes` TUI launches and responds to a "hi" prompt.
+4. Send a Telegram message to the bot → it replies (this confirms `TELEGRAM_BOT_TOKEN` is correct and the bot is whitelisted to your user).
+5. `ls ~/.hermes/sessions/` shows at least one session DB.

--- a/docs/hermes-loom-bootstrap.md
+++ b/docs/hermes-loom-bootstrap.md
@@ -1,0 +1,113 @@
+# Finishing hermes-agent bootstrap on loom
+
+Five steps. ~10 minutes if joostclaw is reachable.
+
+## Prerequisites (already done in PR #33)
+
+- `~/.hermes/` populated by `install.sh`
+- `~/.local/bin/hermes` launcher on PATH
+- Nix-managed systemd unit `hermes-agent-gateway` defined for loom (not yet active — needs step 4)
+
+## Step 1 — Recover credentials from joostclaw
+
+Loom can't decrypt `secrets/joostclaw.yaml` (not a sops recipient). Do this on joostclaw itself:
+
+```bash
+ssh joost@joostclaw
+cd ~/nixos-config        # or wherever you have it cloned
+sops -d secrets/joostclaw.yaml | grep -E "^ironclaw-(anthropic-api-key|telegram-bot-token):"
+```
+
+Note the two values (Anthropic key + Telegram bot token). Don't paste them into chat or commit them — they're real credentials.
+
+If you don't have the repo cloned on joostclaw: `git clone https://github.com/javdl/nixos-config ~/nixos-config` first. sops needs the file at a path it knows; the cloned repo's `secrets/joostclaw.yaml` works fine.
+
+## Step 2 — Fill in `~/.hermes/.env` on loom
+
+Hermes already wrote a template at `~/.hermes/.env` (22 KB, every provider commented out). Edit it:
+
+```bash
+$EDITOR ~/.hermes/.env
+```
+
+Uncomment and fill:
+
+```env
+# Native Anthropic provider (not via OpenRouter)
+ANTHROPIC_API_KEY=<value from step 1>
+
+# Telegram channel
+TELEGRAM_BOT_TOKEN=<value from step 1>
+TELEGRAM_ALLOWED_USERS=5654206852    # your numeric Telegram user id
+```
+
+(`5654206852` is your existing allowlist — same value `openclaw-work01` and `ironclaw-main` used. Replace if you want a different bot.)
+
+## Step 3 — Configure providers + model
+
+```bash
+hermes setup
+```
+
+Interactive menu — pick:
+- **LLM provider:** Anthropic (it'll auto-detect the key from `~/.hermes/.env`)
+- **Default model:** `anthropic/claude-opus-4.6` (or whatever you want)
+- **Channels:** enable Telegram
+
+This writes `~/.hermes/config.yaml`. Sanity-check:
+```bash
+hermes config
+```
+
+Optional smoke-test the TUI before going daemon:
+```bash
+hermes
+# > hi
+# (Ctrl+D or `/exit` to quit)
+```
+
+## Step 4 — Activate the Nix-managed systemd unit
+
+```bash
+cd ~/nixos-config
+make switch NIXNAME=loom
+systemctl --user daemon-reload
+systemctl --user enable --now hermes-agent-gateway
+```
+
+Verify:
+```bash
+systemctl --user status hermes-agent-gateway
+journalctl --user -u hermes-agent-gateway -f
+```
+
+Should show `active (running)` and "telegram channel initialized" (or similar) in the logs. If you see warnings about "No messaging platforms enabled", `hermes setup` step didn't enable Telegram — re-run it.
+
+## Step 5 — Smoke-test end-to-end
+
+Send a message to your Telegram bot from your phone. It should reply.
+
+If it doesn't:
+- `journalctl --user -u hermes-agent-gateway --since "5 min ago"` for runtime errors
+- Confirm bot is reachable: `curl -s "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/getMe"` (read the token out of `~/.hermes/.env`)
+- Confirm your user ID is in `TELEGRAM_ALLOWED_USERS` — hermes rejects unknown users silently
+
+## Operational commands going forward
+
+| Action | Command |
+|---|---|
+| Start | `systemctl --user start hermes-agent-gateway` |
+| Stop | `systemctl --user stop hermes-agent-gateway` |
+| Restart (e.g. after editing `~/.hermes/.env`) | `systemctl --user restart hermes-agent-gateway` |
+| Logs (live) | `journalctl --user -u hermes-agent-gateway -f` |
+| Logs (today) | `journalctl --user -u hermes-agent-gateway --since today` |
+| Status | `systemctl --user status hermes-agent-gateway` |
+| Update hermes | `hermes update` (in-place, no Nix involvement) |
+| Edit config | `hermes config edit` or directly `$EDITOR ~/.hermes/config.yaml` |
+| Edit secrets | `$EDITOR ~/.hermes/.env` then `systemctl --user restart hermes-agent-gateway` |
+
+**Do NOT run `hermes gateway install`** — that creates a second, hermes-managed unit (`hermes-gateway.service`) that fights the Nix-managed one. The Nix unit already runs the same underlying command (`hermes gateway run`).
+
+## Once you're confident it works
+
+Open a separate cleanup PR to remove the now-unused `ironclaw-*` and `openclaw-*` entries from `secrets/joostclaw.yaml`. Run `sops secrets/joostclaw.yaml` on joostclaw itself (loom can't decrypt). Or leave them — they're inert.

--- a/users/joost/home-manager-server.nix
+++ b/users/joost/home-manager-server.nix
@@ -1,4 +1,4 @@
-{ isWSL, inputs, ... }:
+{ isWSL, inputs, currentSystemName, ... }:
 
 { config, lib, pkgs, ... }:
 
@@ -629,6 +629,43 @@ in {
     };
     Install.WantedBy = [ "default.target" ];
   };
+
+  # Hermes Agent gateway (NousResearch/hermes-agent — personal AI with built-in
+  # Telegram/Discord/Slack channels + cron scheduler).
+  #
+  # Loom-only. Other server-shaped hosts that share this home-manager file
+  # (desmondroid, jacksonator, peterbot, rajbot, etc.) don't get this unit.
+  #
+  # Bootstrap (one-time, manual):
+  #   1. curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh \
+  #        | bash -s -- --skip-setup
+  #   2. hermes setup                  # interactive provider config (Anthropic key, model)
+  #   3. ${EDITOR:-vim} ~/.hermes/.env # fill in TELEGRAM_BOT_TOKEN, TELEGRAM_ALLOWED_USERS, etc.
+  #   4. systemctl --user daemon-reload && systemctl --user enable --now hermes-agent-gateway
+  #
+  # The unit idles cleanly when no platforms are configured — safe to enable
+  # before step 3 is finished, just won't actually serve messages yet.
+  #
+  # Do NOT run `hermes gateway install` — that creates a duplicate hermes-managed
+  # unit (~/.config/systemd/user/hermes-gateway.service) that fights this one.
+  # Use `systemctl --user start/stop/restart hermes-agent-gateway` instead.
+  systemd.user.services.hermes-agent-gateway =
+    lib.mkIf (isLinux && currentSystemName == "loom") {
+      Unit = {
+        Description = "Hermes Agent messaging gateway (Telegram/Discord/Slack + cron)";
+        Documentation = [ "https://hermes-agent.nousresearch.com/docs/" ];
+        After = [ "network-online.target" ];
+        Wants = [ "network-online.target" ];
+      };
+      Service = {
+        Type = "simple";
+        ExecStart = "%h/.local/bin/hermes gateway run";
+        # Hermes reads ~/.hermes/.env itself; no EnvironmentFile needed.
+        Restart = "on-failure";
+        RestartSec = 10;
+      };
+      Install.WantedBy = [ "default.target" ];
+    };
 
   programs.zellij = {
     enable = true;


### PR DESCRIPTION
## Summary

Two things in this PR:

1. **Ran `install.sh` on loom.** Hermes is installed at `~/.hermes/`, launcher at `~/.local/bin/hermes`. Already verified `hermes gateway run` works.

2. **Added a Nix-managed systemd user service** in `users/joost/home-manager-server.nix` (loom's actual home-manager file — loom is `server = true` in flake.nix so it loads the `-server` variant, not `home-manager.nix`).

Plus the plan rewrite from the previous push.

## Why a Nix-managed unit (not `hermes gateway install`)

Hermes ships its own `hermes gateway install` command that creates a systemd user unit at `~/.config/systemd/user/hermes-gateway.service`. That works fine, but it's runtime-created — not in version control, not declarative, conflicts with how everything else on loom is managed.

The Nix-managed unit lives at `users/joost/home-manager-server.nix:632`, runs `hermes gateway run` (the foreground daemon mode that `hermes gateway install`'s own unit also runs underneath). Trade-off documented in the inline comment: **don't run `hermes gateway install`** afterwards — the two units would fight.

## What's loom-only and how

```nix
systemd.user.services.hermes-agent-gateway =
  lib.mkIf (isLinux && currentSystemName == "loom") {
    ...
  };
```

`users/joost/home-manager-server.nix` had to grow a new arg in its outer function signature (`currentSystemName, ...`) — mksystem.nix was already passing it, the file just wasn't reading it. Verified with `nix-instantiate`:
- `loom.config.home-manager.users.joost.systemd.user.services` → `["agent-mail" "gpg-agent" "hermes-agent-gateway" "ssh-agent"]` ✅
- `joostclaw.config...` → `["gpg-agent" "ssh-agent"]` (joostclaw uses a different home-manager file) ✅

## Bootstrap state

| Step | State |
|---|---|
| 1. `install.sh --skip-setup` on loom | ✅ done in this PR |
| 2. Recover Anthropic key + Telegram token from `secrets/joostclaw.yaml` | ⏳ user action (loom can't decrypt — needs to `sops -d` on joostclaw and copy) |
| 3. Fill in `~/.hermes/.env` (hermes self-created the template) | ⏳ user action |
| 4. `hermes setup` (interactive provider config) | ⏳ user action |
| 5. `make switch NIXNAME=loom` + `systemctl --user enable --now hermes-agent-gateway` | ⏳ user action |
| 6. Verify Telegram bot replies | ⏳ user action |

## Validation

- `nix build .#nixosConfigurations.loom.config.system.build.toplevel` ✅
- Eval check confirms the unit appears on loom and nowhere else.
- `~/.local/bin/hermes gateway run` runs and idles cleanly with no platforms enabled (won't crash-loop pre-config).

## Files changed

| File | Change |
|---|---|
| `Plans/add-hermes-agent.md` | Updated: step 1 marked done, step 3 simplified to edit `~/.hermes/.env` in place (hermes already templates it), bootstrap flow ends with `systemctl --user enable --now`. |
| `users/joost/home-manager-server.nix` | Added `currentSystemName` to outer function args + a new `systemd.user.services.hermes-agent-gateway` block gated on `currentSystemName == "loom"`. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
