### PR TITLE
[codex] fix(chezmoi-memory-sync): PATH must be set inside the script for systemd

### DIFF
--- a/hosts/mac-shared.nix
+++ b/hosts/mac-shared.nix
@@ -128,12 +128,10 @@ in {
 
     # Auto-sync ~/.claude/MEMORY to chezmoi git remote every 5 minutes.
     # Why: cross-machine sync of WORK PRDs and STATE without manual chezmoi re-add.
+    # Script sets its own PATH (see lib/chezmoi-memory-sync.nix) so no shell wrapper needed.
     launchd.user.agents.chezmoi-memory-sync = {
       serviceConfig = {
-        ProgramArguments = [
-          "/bin/sh" "-c"
-          ''export PATH="/etc/profiles/per-user/$USER/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin"; exec ${chezmoiMemorySync}''
-        ];
+        ProgramArguments = [ "${chezmoiMemorySync}" ];
         RunAtLoad = true;
         StartInterval = 300;
         StandardOutPath = "/tmp/chezmoi-memory-sync.log";

--- a/lib/chezmoi-memory-sync.nix
+++ b/lib/chezmoi-memory-sync.nix
@@ -8,6 +8,13 @@
 # Both schedule it every 5 minutes. Body is identical across platforms.
 pkgs: pkgs.writeShellScript "chezmoi-memory-sync" ''
   set -u
+
+  # systemd user services start with a minimal PATH that lacks chezmoi/jj/grep.
+  # Set PATH explicitly so the script works under both systemd (loom) and
+  # launchd (Darwin) without needing per-consumer wrapping. These paths are
+  # present on both NixOS and nix-darwin.
+  export PATH="/etc/profiles/per-user/$USER/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin"
+
   CHEZMOI_SRC="$HOME/.local/share/chezmoi"
   MEMORY_LIVE="$HOME/.claude/MEMORY"
   MEMORY_SRC_PATH="dot_claude/MEMORY"


### PR DESCRIPTION
## Summary

Fixes a real-world bug in the just-merged `chezmoi-memory-sync` Linux setup (PR #35): systemd user services run with a minimal PATH that doesn't include `chezmoi`, `jj`, or `grep`. The first live run on loom logged `chezmoi: command not found` and exited 0 without doing anything.

## Root cause

Darwin's launchd wrapped the script in `/bin/sh -c "export PATH=...; exec ${script}"` so the explicit PATH carried into the script. The new Linux systemd unit invoked the script directly without that wrapper. The shared script body assumed PATH was already set up by the consumer.

## Fix

Move the PATH export **into the script body itself** (in `lib/chezmoi-memory-sync.nix`). Now both consumers can invoke the script directly with no shell wrapper:

```nix
# lib/chezmoi-memory-sync.nix
pkgs: pkgs.writeShellScript "chezmoi-memory-sync" ''
  set -u
  export PATH="/etc/profiles/per-user/$USER/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin"
  ...
''
```

`hosts/mac-shared.nix` launchd block simplified from `ProgramArguments = [ "/bin/sh" "-c" ''export PATH=...; exec ${chezmoiMemorySync}'' ]` to `ProgramArguments = [ "${chezmoiMemorySync}" ]`. Equivalent behavior, less plumbing.

## End-to-end verification

After `make switch NIXNAME=loom`:
```
systemctl --user daemon-reload
systemctl --user start chezmoi-memory-sync.service
systemctl --user status chezmoi-memory-sync.service
```

Service exited 0 cleanly. Logs showed:
```
Changes to push to origin:
  Move forward bookmark main from 4cc98f7bd1d2 to 10781f718dd4
chore(memory): auto-sync 2026-05-12T20:55Z
```

`jj log -r 'main@origin'` on `~/.local/share/chezmoi` now shows the auto-sync commit on `javdl/dotfiles@main` — **first Linux-sourced auto-sync commit** (committer `joost+agent@fashionunited.com` from loom).

`systemctl --user list-timers chezmoi-memory-sync.timer` shows the timer armed with its next firing.

## Lessons captured

This is a textbook case of "verify after change" (the operating principle merged in PR #34): the unit eval'd correctly, built clean, started successfully — but only **executing the runtime path** revealed the PATH-stripping. The previous PR's verification (`nix eval` + `nix build`) was necessary but not sufficient. Adding to the lessons-learned for next time.

## Test plan

- [x] `make switch NIXNAME=loom` succeeds
- [x] `systemctl --user start chezmoi-memory-sync.service` exits 0 with logs showing real work
- [x] First Linux-sourced `chore(memory): auto-sync ...Z` commit lands on `javdl/dotfiles@main`
- [x] `systemctl --user list-timers chezmoi-memory-sync.timer` shows timer armed
- [ ] Wait ~5 min and confirm second firing happens automatically (deferred — PR is correct based on triggered run)
- [ ] Verify Darwin path didn't regress next time a Mac switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
