### PR TITLE
[codex] add just and rumdl to home-manager packages

### DIFF
--- a/users/joost/home-manager.nix
+++ b/users/joost/home-manager.nix
@@ -118,6 +118,7 @@ in {
     httpie
     imagemagick
     jq
+    just # Command runner (justfiles)
     # kubernetes-helm
     # libGL # ML
     # libGLU # ML
@@ -129,6 +130,7 @@ in {
     railway
     ripgrep
     ast-grep
+    rumdl # Markdown linter/formatter in Rust
     shellcheck
     shfmt
     socat


### PR DESCRIPTION
## Summary

Adds two CLI tools to `users/joost/home-manager.nix` `home.packages`:

- **`just`** (1.51.0) — command runner for `justfile` recipes
- **`rumdl`** (0.1.94) — Rust markdown linter/formatter

Both resolve directly from the flake's pinned nixpkgs (26.05), so no overlay/`fetchurl` packaging was needed.

## Notes

- A third tool, **`prek`**, was requested but was already present in the package list (line 182, "better pre-commit, written in Rust") — no change needed there, and a duplicate I initially added was removed.
- Both packages were added to the **base** (unconditional) list, so they install on all hosts including the minimal `fu146` scraper machine.

## Validation

`nix eval` of the evaluated `home.packages` set for `fu146` returns exactly `[ just-1.51.0 rumdl-0.1.94 prek-0.3.11 ]` — confirming the tools resolve, come from the pinned nixpkgs, and produce no duplicate-derivation collision.
