### PR TITLE
chore: update overlay tool versions to latest upstream

### DIFF
--- a/.github/prompts/update-overlay-tools.md
+++ b/.github/prompts/update-overlay-tools.md
@@ -1,0 +1,63 @@
+Update the pinned versions of the pre-built third-party tools in `lib/overlays.nix`
+to their latest upstream releases, recomputing every hash. Work autonomously; do not
+ask questions.
+
+## What is pinned
+
+`lib/overlays.nix` packages ~25 CLI tools (codex, beads_rust/`br`, ntm, dcg, caam,
+cass, ubs, gemini-cli, agent-browser, etc.). Each tool has:
+
+- a `<name>Version = "x.y.z";` Nix variable, and
+- a per-platform source set with a `url` and a `sha256` (nix base32 **or** hex) or a
+  `hash` (SRI `sha256-...`) field.
+
+A few are special: `ubs` fetches a main script plus ~10 module + ~13 helper files
+each with its own hash; `cass-memory` builds from source via `fetchFromGitHub` + a
+fixed-output `bunDeps` derivation (`outputHash`); `cco` is pinned to a git commit
+(leave it unless there is an obvious newer tagged release — never guess a commit).
+
+## Procedure
+
+For each `*Version` variable:
+
+1. Find the latest release. GitHub: `gh api repos/<owner>/<repo>/releases/latest --jq .tag_name`.
+   npm (codex): `curl -s https://registry.npmjs.org/@openai/codex/latest | jq -r .version`.
+   The owner/repo is visible in each tool's `url`.
+2. If the latest equals the current pin, skip the tool.
+3. If newer, bump the version variable and recompute **every** platform hash:
+   - `nix-prefetch-url <url>` gives a nix base32 hash (no `--unpack` for plain
+     fetchurl of a tarball/binary; use `--unpack` for `fetchzip`/`fetchFromGitHub`).
+   - Convert to the format that entry already uses:
+     `nix hash convert --hash-algo sha256 --to base16 <b32>` for hex,
+     `nix hash convert --hash-algo sha256 --to sri <b32>` for SRI.
+4. **Asset names and archive layouts change between releases.** If a download 404s or
+   a build fails, inspect the real release assets
+   (`gh api repos/<owner>/<repo>/releases/tags/<tag> --jq '.assets[].name'`) and the
+   tarball contents (`tar tzf` / `tar tJf`). Update the `url` pattern, archive
+   extension, `unpackPhase`, `sourceRoot`, install path, and the `meta.platforms`
+   list as needed. If a platform's asset disappears upstream, remove that platform
+   entry; if a new platform appears, you may add it.
+5. For `cass-memory`: bump `rev`, recompute the `fetchFromGitHub` `hash`
+   (`nix-prefetch-url --unpack https://github.com/<owner>/<repo>/archive/<tag>.tar.gz`,
+   then `--to sri`), then set the `bunDeps` `outputHash` to
+   `sha256-AAAA...AAA=` (44-char zero placeholder), build it via
+   `nix build .#nixosConfigurations.<somehost>.pkgs.cass-memory --no-link`, and paste
+   the "got:" hash from the mismatch error.
+
+## Validate
+
+- Run `nix fmt lib/overlays.nix` (the repo enforces nixfmt via a CI check).
+- `nix-instantiate --parse lib/overlays.nix` must succeed.
+- For each x86_64-linux tool you changed, confirm it builds:
+  `nix build .#nixosConfigurations.<host>.pkgs.<attr> --no-link` (pick a Linux host
+  from `flake.nix` `nixosConfigurations`; the overlay attr name is the Nix attribute,
+  e.g. `beads-rust`, `destructive-command-guard`, not the binary name). A hash
+  mismatch means you used the wrong hash; a builder failure usually means the archive
+  layout changed (see step 4).
+
+## Output
+
+Only edit files in the working tree — **do not** run `git commit`, `git push`, or open
+a PR yourself; the workflow does that. End by printing a concise markdown summary
+table of `tool | old version | new version` for everything you bumped (and note any
+tool you intentionally skipped because an asset/layout change needs human review).

--- a/.github/workflows/tool-updater.yml
+++ b/.github/workflows/tool-updater.yml
@@ -1,0 +1,69 @@
+name: Overlay 🛠️ Tool Updater ✨
+
+# Weekly: bump the pinned versions of the pre-built CLI tools in lib/overlays.nix
+# (codex, beads_rust, ntm, dcg, cass, ubs, gemini-cli, ...) to their latest upstream
+# releases, recompute every hash, and open a PR. Mirrors the flake lock-updater.
+
+on:
+  schedule:
+    # Mondays at 14:07 UTC (just after the flake.lock updater)
+    - cron: "7 14 * * 1"
+  workflow_dispatch:
+
+# Don't let two updater runs race on the same branch.
+concurrency:
+  group: overlay-tool-updater
+  cancel-in-progress: true
+
+jobs:
+  update-tools:
+    name: Update overlay tool versions
+    runs-on: ubuntu-22.04
+    timeout-minutes: 65
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Claude needs nix-prefetch-url / nix hash convert / nix build to recompute
+      # and verify hashes.
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+      - uses: DeterminateSystems/flakehub-cache-action@main
+
+      - name: Update overlay tool versions with Claude Code
+        uses: ./.github/actions/claude-code-action
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt_file: .github/prompts/update-overlay-tools.md
+          allowed_tools: "Bash,Edit,Read,Write,Grep,Glob"
+          timeout_minutes: "55"
+          # Write outside the repo so the summary is not committed into the PR.
+          output_file: /tmp/claude-summary.md
+
+      - name: Ensure a PR body exists
+        if: always()
+        run: |
+          test -s /tmp/claude-summary.md || \
+            printf 'Automated weekly update of pinned tool versions in `lib/overlays.nix`.\n' \
+            > /tmp/claude-summary.md
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          # PAT (not GITHUB_TOKEN) so the PR's CI checks actually run.
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          branch: automated/overlay-tool-updates
+          delete-branch: true
+          # Only ever commit the overlay file — never the action's stray
+          # output.txt / output.json scratch files.
+          add-paths: lib/overlays.nix
+          commit-message: "chore: update overlay tool versions"
+          title: "chore: update overlay tool versions"
+          body-path: /tmp/claude-summary.md
+          labels: |
+            dependencies
+            automated

--- a/lib/overlays.nix
+++ b/lib/overlays.nix
@@ -1,538 +1,659 @@
 { inputs }:
 [
-      # inputs.jujutsu.overlays.default
-      # inputs.zig.overlays.default
+  # inputs.jujutsu.overlays.default
+  # inputs.zig.overlays.default
 
-      (final: prev:
+  (
+    final: prev:
+    let
+      # Import nixpkgs-unstable with allowUnfree enabled.
+      #
+      # NOTE: this is a second, independent nixpkgs instantiation (in addition to
+      # the host's stable `prev`). It is evaluated once per overlay application
+      # (i.e. per system), and unstable packages pulled from it do NOT inherit the
+      # host's nixpkgs.config (only allowUnfree is set here). That is intentional:
+      # we want unstable packages built against the unstable tree, not the stable
+      # one. The eval-time cost is small and shared across all packages below.
+      pkgs-unstable = import inputs.nixpkgs-unstable {
+        system = prev.stdenv.hostPlatform.system;
+        config.allowUnfree = true;
+      };
+
+      # grepai - semantic code search CLI tool
+      grepaiVersion = "0.35.0";
+      grepaiSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/yoanbernabeu/grepai/releases/download/v${grepaiVersion}/grepai_${grepaiVersion}_linux_amd64.tar.gz";
+          sha256 = "1cirq9gy4k5fb53n86xmkxkq0835l7z4yxq7hb4v17bxgazy0c58";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/yoanbernabeu/grepai/releases/download/v${grepaiVersion}/grepai_${grepaiVersion}_linux_arm64.tar.gz";
+          sha256 = "0jmamir89h6l2wjznpj4x3mamn6kdajiyxjzhbpxbdvcycchw25s";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/yoanbernabeu/grepai/releases/download/v${grepaiVersion}/grepai_${grepaiVersion}_darwin_amd64.tar.gz";
+          sha256 = "0mwwya2r0yl6njfq72h9s9ivnn67hjfk4rl2dcyxn06xsm1fx9nv";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/yoanbernabeu/grepai/releases/download/v${grepaiVersion}/grepai_${grepaiVersion}_darwin_arm64.tar.gz";
+          sha256 = "1zdwqm2bi5bxnz45vy7vzggv5914b4za2yrr21dbkl44p71blwz8";
+        };
+      };
+      grepaiSource =
+        grepaiSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for grepai: ${prev.stdenv.hostPlatform.system}");
+
+      # beads_viewer (bv) - TUI for beads issue tracking
+      bvVersion = "0.17.0";
+      bvSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/beads_viewer/releases/download/v${bvVersion}/bv_${bvVersion}_linux_amd64.tar.gz";
+          sha256 = "079mqichhg79f273v13kbs6w5i9g687iqsmy2a4j4j32pawb1yjq";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/Dicklesworthstone/beads_viewer/releases/download/v${bvVersion}/bv_${bvVersion}_linux_arm64.tar.gz";
+          sha256 = "1zrbhprzcy06m9gbk7hskwry5fi6qrfcm4skmkjhn9sv9vpafdan";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/beads_viewer/releases/download/v${bvVersion}/bv_${bvVersion}_darwin_amd64.tar.gz";
+          sha256 = "1zaycdz6is79fzb6jav984f725db9wg5nvjis9khq5rb8kxcq60h";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/beads_viewer/releases/download/v${bvVersion}/bv_${bvVersion}_darwin_arm64.tar.gz";
+          sha256 = "167n6nbhk1kfhgsq5xsx5gg9r498gqry0zajdkp61ad8k4clny46";
+        };
+      };
+      bvSource =
+        bvSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for bv: ${prev.stdenv.hostPlatform.system}");
+
+      # cass - coding agent session search
+      cassVersion = "0.6.13";
+      cassSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/coding_agent_session_search/releases/download/v${cassVersion}/cass-linux-amd64.tar.gz";
+          sha256 = "1ifli5g7hb8r93zdc7c90mwbz5b9nnfnc8gbljvl2ds4hqpyp8c9";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/Dicklesworthstone/coding_agent_session_search/releases/download/v${cassVersion}/cass-linux-arm64.tar.gz";
+          sha256 = "0lfh1rji1vpxl09ycys14shr2159zcr1k5sa22a8c9r9g9qhj0vr";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/coding_agent_session_search/releases/download/v${cassVersion}/cass-darwin-arm64.tar.gz";
+          sha256 = "0viskn46nahzsz1vcikdjkjah387l56fl7xrs7hq39rrfwy5rkja";
+        };
+      };
+      cassSource = cassSources.${prev.stdenv.hostPlatform.system} or null;
+
+      # slb - Shannon Language Benchmark for LLM evaluation
+      slbVersion = "0.3.1";
+      slbSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/slb/releases/download/v${slbVersion}/slb_${slbVersion}_linux_amd64.tar.gz";
+          sha256 = "0b9c489fe025d77c8e0d6b992b2cd94d46e74a2a294e480c57274df5d634027b";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/Dicklesworthstone/slb/releases/download/v${slbVersion}/slb_${slbVersion}_linux_arm64.tar.gz";
+          sha256 = "88f3ec9cb5fa03431b13ed840423c7d0946ca32b4a3dcc0edd5a0f934419917d";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/slb/releases/download/v${slbVersion}/slb_${slbVersion}_darwin_amd64.tar.gz";
+          sha256 = "c8c2d745a95d702b65c6ae42fe8f8c56633ce2585857fe635af9a8a3e6ae9109";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/slb/releases/download/v${slbVersion}/slb_${slbVersion}_darwin_arm64.tar.gz";
+          sha256 = "185bef18d345f406692430929860edbfc092a9e9406b868471eed2365e438bc6";
+        };
+      };
+      slbSource =
+        slbSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for slb: ${prev.stdenv.hostPlatform.system}");
+
+      # csctf - Chat Shared Conversation To File
+      csctfVersion = "0.4.5";
+      csctfSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/chat_shared_conversation_to_file/releases/download/v${csctfVersion}/csctf-linux-x64";
+          sha256 = "bb58bbd35de1d408b5fede47c61a7ff89038983043d8f735888d72a095b7fef3";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/Dicklesworthstone/chat_shared_conversation_to_file/releases/download/v${csctfVersion}/csctf-linux-arm64";
+          sha256 = "3dc185dd7eb466fc6c6f77d388fd6e76628a1e1ddd3248869ae9b6792df76875";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/chat_shared_conversation_to_file/releases/download/v${csctfVersion}/csctf-macos-x64";
+          sha256 = "42075d7ef82c3b17a6419a4033b7a219478ce162fb605668f0048843b06a5265";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/chat_shared_conversation_to_file/releases/download/v${csctfVersion}/csctf-macos-arm64";
+          sha256 = "d5d88aeb20c13bded9e186b89a3c0d7f00705fbc658ee5a41766a84f7da90e7c";
+        };
+      };
+      csctfSource =
+        csctfSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for csctf: ${prev.stdenv.hostPlatform.system}");
+
+      # brenner - Sydney Brenner research platform CLI
+      brennerVersion = "0.4.0";
+      brennerSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/brenner_bot/releases/download/v${brennerVersion}/brenner-linux-x64";
+          sha256 = "2c5a5f01987c30933228d4b62c80e2d20ad872af60bd83604daa6b370e1f8ca3";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/Dicklesworthstone/brenner_bot/releases/download/v${brennerVersion}/brenner-linux-arm64";
+          sha256 = "70595c1a82961db9fa4defe5675b01bbe0e0cc0875e8e33f4f02bb8273e64caa";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/brenner_bot/releases/download/v${brennerVersion}/brenner-darwin-x64";
+          sha256 = "8c00ef0dd923389a8870c58514af54c5ff771c056c81106938627428ce71b501";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/brenner_bot/releases/download/v${brennerVersion}/brenner-darwin-arm64";
+          sha256 = "1cf5e88d600c488999d341cb8e5a256d54127739de1c7ea6d12853dc9442b916";
+        };
+      };
+      brennerSource =
+        brennerSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for brenner: ${prev.stdenv.hostPlatform.system}");
+
+      # toon - Token-Optimized Object Notation converter (JSON <-> TOON)
+      toonVersion = "0.2.3";
+      toonSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/toon_rust/releases/download/v${toonVersion}/toon-linux-amd64.tar.xz";
+          sha256 = "069e4b7f4a10c46f0f06fcf85f8511638a831b931579edf6cae606d27d11f0bf";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/Dicklesworthstone/toon_rust/releases/download/v${toonVersion}/toon-linux-arm64.tar.xz";
+          sha256 = "41b6cbae1358e62508e3833d84b16593e04716b4f1ee1fbd832655c632ad8877";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/toon_rust/releases/download/v${toonVersion}/toon-darwin-amd64.tar.xz";
+          sha256 = "9f60a8b9ae75a890412b16fe5e4e2b2966dddac145b7c98b9490e7f66ad922f1";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/toon_rust/releases/download/v${toonVersion}/toon-darwin-arm64.tar.xz";
+          sha256 = "f5727108b549e135cace95b916c9d1b1f8ceb2cbd8b18ec3c6e3bbee9369590f";
+        };
+      };
+      toonSource =
+        toonSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for toon: ${prev.stdenv.hostPlatform.system}");
+
+      # ms - Meta Skill manager with Thompson sampling optimization
+      msVersion = "0.1.3";
+      msSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/meta_skill/releases/download/v${msVersion}/ms-${msVersion}-x86_64-unknown-linux-gnu.tar.gz";
+          sha256 = "f5edd16cc6264a532f6a32b5c5b3fbc9bd0e7badea5a542522f531baf58ecf0f";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/meta_skill/releases/download/v${msVersion}/ms-${msVersion}-aarch64-apple-darwin.tar.gz";
+          sha256 = "9d58faab4c5be52935d78b4ced34b0ecae1eed8f6b97a901473b983bbb06f5da";
+        };
+      };
+      msSource = msSources.${prev.stdenv.hostPlatform.system} or null;
+
+      # gws - Google Workspace CLI
+      gwsVersion = "0.22.5";
+      gwsSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/googleworkspace/cli/releases/download/v${gwsVersion}/google-workspace-cli-x86_64-unknown-linux-musl.tar.gz";
+          sha256 = "0879hyfdm2ngsmwmwq0s8jkg3waa1ndpcpgk9wp8gaxiwkfp7d2d";
+          dir = ".";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/googleworkspace/cli/releases/download/v${gwsVersion}/google-workspace-cli-aarch64-unknown-linux-musl.tar.gz";
+          sha256 = "16liz5xpdy2czk655zh5c3k51a0ax7n4f2qkq87b2cj9a9izw077";
+          dir = ".";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/googleworkspace/cli/releases/download/v${gwsVersion}/google-workspace-cli-x86_64-apple-darwin.tar.gz";
+          sha256 = "1cj4cmm4vcdh5hjh2k433z6xqmlcsq6y7qindjibpm042irvvyai";
+          dir = ".";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/googleworkspace/cli/releases/download/v${gwsVersion}/google-workspace-cli-aarch64-apple-darwin.tar.gz";
+          sha256 = "1b3x5xbfv3i45j59hhfpayg3vlgshbqdlc46nk2c5cn9bgyryahx";
+          dir = ".";
+        };
+      };
+      gwsSource =
+        gwsSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for gws: ${prev.stdenv.hostPlatform.system}");
+
+      # beads_rust (br) - fast Rust port of beads issue tracker
+      brVersion = "0.2.15";
+      brSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/beads_rust/releases/download/v${brVersion}/br-${brVersion}-linux_amd64.tar.gz";
+          sha256 = "0rx6nh1wskafppjbj6fq9kbss51fwpkqfnfw2w3d90kzmvm0il1q";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/Dicklesworthstone/beads_rust/releases/download/v${brVersion}/br-${brVersion}-linux_arm64.tar.gz";
+          sha256 = "107qg6ma930pdyzzn5d0ayd06h13i2hf88x8x8j460g6x8pkwk1k";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/beads_rust/releases/download/v${brVersion}/br-${brVersion}-darwin_amd64.tar.gz";
+          sha256 = "0pfsza4fyxmc0f51hvk30s20m11r02rh4ay05hkh265aqrgqgdih";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/beads_rust/releases/download/v${brVersion}/br-${brVersion}-darwin_arm64.tar.gz";
+          sha256 = "17485fqlkm2y72vzmkv4zpv5lva5vg9q9yp02nz2ha6a3qzi6cjf";
+        };
+      };
+      brSource =
+        brSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for br: ${prev.stdenv.hostPlatform.system}");
+
+      # ntm - Named Tmux Manager for AI coding agent coordination
+      ntmVersion = "1.18.3";
+      ntmSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/ntm/releases/download/v${ntmVersion}/ntm_${ntmVersion}_linux_amd64.tar.gz";
+          sha256 = "1iy0pmjgq4xkcjmi2srbkvfl9ar542sr33sgih9n7344nmsnb8b9";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/Dicklesworthstone/ntm/releases/download/v${ntmVersion}/ntm_${ntmVersion}_linux_arm64.tar.gz";
+          sha256 = "1pds5v6599k05bpbrbyca2zxa3rfndv54b36hj2mg9dcdxhq4z6s";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/ntm/releases/download/v${ntmVersion}/ntm_${ntmVersion}_darwin_all.tar.gz";
+          sha256 = "0054v2v389z1361288rria9rncxyzpyf0vdzkihkz7r1r905rihy";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/ntm/releases/download/v${ntmVersion}/ntm_${ntmVersion}_darwin_all.tar.gz";
+          sha256 = "0054v2v389z1361288rria9rncxyzpyf0vdzkihkz7r1r905rihy";
+        };
+      };
+      ntmSource =
+        ntmSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for ntm: ${prev.stdenv.hostPlatform.system}");
+
+      # dcg - destructive command guard
+      dcgVersion = "0.5.7";
+      dcgSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/destructive_command_guard/releases/download/v${dcgVersion}/dcg-x86_64-unknown-linux-musl.tar.xz";
+          sha256 = "3cb7297ac90a01b82e6165b5ee0a74b8b673250e4a0ab9182d5dbe396a467cde";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/Dicklesworthstone/destructive_command_guard/releases/download/v${dcgVersion}/dcg-aarch64-unknown-linux-gnu.tar.xz";
+          sha256 = "20b5b5cc53663d17cbfe0fa84c125ce868b2e02d009edfcb8fa83f9ab4087572";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/destructive_command_guard/releases/download/v${dcgVersion}/dcg-x86_64-apple-darwin.tar.xz";
+          sha256 = "d3284f41e90b5329d52e1db97b0975797f75fd554fc306af4f00ce9cd3c691ab";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/destructive_command_guard/releases/download/v${dcgVersion}/dcg-aarch64-apple-darwin.tar.xz";
+          sha256 = "0fe51d2ea47d5230ae8c2d30cddbe076daa2a1be04846e9352968b0d9a5df283";
+        };
+      };
+      dcgSource =
+        dcgSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for dcg: ${prev.stdenv.hostPlatform.system}");
+
+      # caam - coding agent account manager (instant auth switching)
+      caamVersion = "0.1.11";
+      caamSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/coding_agent_account_manager/releases/download/v${caamVersion}/caam_${caamVersion}_linux_amd64.tar.gz";
+          sha256 = "e0a4e7e3e27c6b3e4f36f7e69ac23f3d59135702d713109de4a4431422a02845";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/Dicklesworthstone/coding_agent_account_manager/releases/download/v${caamVersion}/caam_${caamVersion}_linux_arm64.tar.gz";
+          sha256 = "65e7808cd8d90e06ba10bb755f728ac55c4ff2c97f4bc50b7af8cf56b0e2f242";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/coding_agent_account_manager/releases/download/v${caamVersion}/caam_${caamVersion}_darwin_amd64.tar.gz";
+          sha256 = "dd89be148a8a9c4dd697df296403c00db302ed458fd93e89bcd83f452711478f";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/coding_agent_account_manager/releases/download/v${caamVersion}/caam_${caamVersion}_darwin_arm64.tar.gz";
+          sha256 = "3863fb2ddfde51e4e6bded0498c933e0589487ae8a2211b216312840d242a205";
+        };
+      };
+      caamSource =
+        caamSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for caam: ${prev.stdenv.hostPlatform.system}");
+
+      # agent-browser - browser automation CLI for AI agents
+      agentBrowserVersion = "0.27.3";
+      agentBrowserSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/vercel-labs/agent-browser/releases/download/v${agentBrowserVersion}/agent-browser-linux-x64";
+          sha256 = "0ls3fqvpf2p25jw47bvj6glsrpmqfq39zdsh59ph4p4i5w702grp";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/vercel-labs/agent-browser/releases/download/v${agentBrowserVersion}/agent-browser-linux-arm64";
+          sha256 = "0rakyqjy3jcs5ad5z1z3n8x6n1ssacmaf4d99mansxfh12a3dg1l";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/vercel-labs/agent-browser/releases/download/v${agentBrowserVersion}/agent-browser-darwin-x64";
+          sha256 = "0bzms2c6wnpjrfswsw8pjp3rlhl5dc6qvm5jlx5ynvnv1pd82vhd";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/vercel-labs/agent-browser/releases/download/v${agentBrowserVersion}/agent-browser-darwin-arm64";
+          sha256 = "08rp13knhz6v3x9jrq4rgaifa6nbh2h4r6pvv7fcm7gcx9wdv7jq";
+        };
+      };
+      agentBrowserSource =
+        agentBrowserSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for agent-browser: ${prev.stdenv.hostPlatform.system}");
+
+      # pi - prompt injection detection agent (Rust)
+      piVersion = "0.1.18";
+      piSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/pi_agent_rust/releases/download/v${piVersion}/pi-linux-amd64.tar.xz";
+          sha256 = "0ix87mphpa2bkcmpl6pryjxr69npb6g9k7r1av4l26bjfb02fkmi";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/pi_agent_rust/releases/download/v${piVersion}/pi-darwin-arm64.tar.xz";
+          sha256 = "1sln14rrrsmmjqm6j9f2zqa09qmy303pzvcyr8pv4cs5x897d522";
+        };
+      };
+      piSource = piSources.${prev.stdenv.hostPlatform.system} or null;
+
+      # xf - cross-format file converter
+      xfVersion = "0.3.2";
+      xfSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/xf/releases/download/v${xfVersion}/xf-x86_64-unknown-linux-gnu.tar.gz";
+          sha256 = "2f6820fb391ba36ff0c1920eff965a4db22040fbe353f05d071002a876fa507a";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/xf/releases/download/v${xfVersion}/xf-aarch64-apple-darwin.tar.gz";
+          sha256 = "f3a6527091e0906b58e8b1b11fd5a2632293d22fcce1c50facb661aea3c9e697";
+        };
+      };
+      xfSource = xfSources.${prev.stdenv.hostPlatform.system} or null;
+
+      # mcp-agent-mail - Rust replacement for Python mcp_agent_mail
+      mcpAgentMailVersion = "0.3.10";
+      mcpAgentMailSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/mcp_agent_mail_rust/releases/download/v${mcpAgentMailVersion}/mcp-agent-mail-x86_64-unknown-linux-gnu.tar.xz";
+          sha256 = "0mb7vb6n41q28kjsc6rn9qwd40bdrfrhbdfbsi0k3c05iqi7h82m";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/mcp_agent_mail_rust/releases/download/v${mcpAgentMailVersion}/mcp-agent-mail-aarch64-apple-darwin.tar.xz";
+          sha256 = "0qa80027jax2fqscv6s8vmc2r5v9l9r9g28jfgikklj73kxgcpl7";
+        };
+      };
+      mcpAgentMailSource = mcpAgentMailSources.${prev.stdenv.hostPlatform.system} or null;
+
+      # casr - cross agent session resumer
+      casrVersion = "0.2.3";
+      casrSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/cross_agent_session_resumer/releases/download/v${casrVersion}/casr-x86_64-unknown-linux-musl.tar.xz";
+          sha256 = "22c17f5ce2cb0ca12f98a32eae513c93b879bb9fdac4b5dd4e4861dc1a230d28";
+        };
+      };
+      casrSource = casrSources.${prev.stdenv.hostPlatform.system} or null;
+
+      # s2p - source to prompt TUI (bare binary, no tarball)
+      s2pVersion = "0.3.2";
+      s2pSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/source_to_prompt_tui/releases/download/v${s2pVersion}/s2p-linux-x64";
+          sha256 = "0f1q10b1bffs9c0hsp5glljdc7qi959j3wg7jf0mkcflr6lbhydw";
+        };
+        "aarch64-linux" = {
+          url = "https://github.com/Dicklesworthstone/source_to_prompt_tui/releases/download/v${s2pVersion}/s2p-linux-arm64";
+          sha256 = "13bi0rsc7am8mq6ix2qw22m8hbibrj3wrs1g4mxrkayldj456yqb";
+        };
+        "x86_64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/source_to_prompt_tui/releases/download/v${s2pVersion}/s2p-macos-x64";
+          sha256 = "0cgd8c55zcm7d9s4pi55144h322kiwl2bglfvhi687br3xy46s0d";
+        };
+        "aarch64-darwin" = {
+          url = "https://github.com/Dicklesworthstone/source_to_prompt_tui/releases/download/v${s2pVersion}/s2p-macos-arm64";
+          sha256 = "1j70lj8gkkvl8fnxfgqn7i10djhw6zg7z82dx9wf17crqfw20j4w";
+        };
+      };
+      s2pSource =
+        s2pSources.${prev.stdenv.hostPlatform.system}
+          or (throw "Unsupported system for s2p: ${prev.stdenv.hostPlatform.system}");
+
+      # pt - process triage (intelligent process termination)
+      ptVersion = "2.1.0";
+      ptSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/process_triage/releases/download/v${ptVersion}/pt-core-linux-x86_64-${ptVersion}.tar.gz";
+          sha256 = "81d8c503432c35085ef6082f957412ba42760ab7606c8ef15d9c8cdca0f3ba97";
+        };
+      };
+      ptSource = ptSources.${prev.stdenv.hostPlatform.system} or null;
+
+      # rch - remote compilation helper
+      rchVersion = "1.0.41";
+      rchSources = {
+        "x86_64-linux" = {
+          url = "https://github.com/Dicklesworthstone/remote_compilation_helper/releases/download/v${rchVersion}/rch-v${rchVersion}-x86_64-unknown-linux-gnu.tar.gz";
+          sha256 = "259f647ad303c3a3c62e1604e5e1f21ab9e192fd240e44af0055edfa4c24699d";
+        };
+      };
+      rchSource = rchSources.${prev.stdenv.hostPlatform.system} or null;
+    in
+    {
+      # grepai - semantic code search for AI coding assistants
+      grepai = prev.stdenv.mkDerivation {
+        pname = "grepai";
+        version = grepaiVersion;
+
+        src = prev.fetchurl {
+          url = grepaiSource.url;
+          sha256 = grepaiSource.sha256;
+        };
+
+        sourceRoot = ".";
+
+        nativeBuildInputs = [ prev.gnutar ];
+
+        unpackPhase = ''
+          tar xzf $src
+        '';
+
+        installPhase = ''
+          mkdir -p $out/bin
+          cp grepai $out/bin/
+          chmod +x $out/bin/grepai
+        '';
+
+        meta = with prev.lib; {
+          description = "Semantic code search CLI tool for AI coding assistants";
+          homepage = "https://github.com/yoanbernabeu/grepai";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
+      # bv - beads viewer TUI for issue tracking
+      beads-viewer = prev.stdenv.mkDerivation {
+        pname = "beads-viewer";
+        version = bvVersion;
+
+        src = prev.fetchurl {
+          url = bvSource.url;
+          sha256 = bvSource.sha256;
+        };
+
+        sourceRoot = ".";
+
+        nativeBuildInputs = [ prev.gnutar ];
+
+        unpackPhase = ''
+          tar xzf $src
+        '';
+
+        installPhase = ''
+          mkdir -p $out/bin
+          cp bv $out/bin/
+          chmod +x $out/bin/bv
+        '';
+
+        meta = with prev.lib; {
+          description = "Elegant TUI for the Beads issue tracking system";
+          homepage = "https://github.com/Dicklesworthstone/beads_viewer";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
+
+      # ubs - ultimate bug scanner for AI-assisted code quality
+      ubs =
         let
-          # Import nixpkgs-unstable with allowUnfree enabled
-          pkgs-unstable = import inputs.nixpkgs-unstable {
-            system = prev.stdenv.hostPlatform.system;
-            config.allowUnfree = true;
-          };
-
-          # grepai - semantic code search CLI tool
-          grepaiVersion = "0.35.0";
-          grepaiSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/yoanbernabeu/grepai/releases/download/v${grepaiVersion}/grepai_${grepaiVersion}_linux_amd64.tar.gz";
-              sha256 = "1cirq9gy4k5fb53n86xmkxkq0835l7z4yxq7hb4v17bxgazy0c58";
+          ubsVersion = "5.3.2";
+          ubsBaseUrl = "https://raw.githubusercontent.com/Dicklesworthstone/ultimate_bug_scanner/v${ubsVersion}";
+          # Language modules (from v5.3.2 tag)
+          ubsModules = {
+            "ubs-cpp.sh" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/ubs-cpp.sh";
+              sha256 = "01aqm3yq4cb74vqpbj6rcz5jq9rhaihd8669llgyhrmci5qvfm7h";
             };
-            "aarch64-linux" = {
-              url = "https://github.com/yoanbernabeu/grepai/releases/download/v${grepaiVersion}/grepai_${grepaiVersion}_linux_arm64.tar.gz";
-              sha256 = "0jmamir89h6l2wjznpj4x3mamn6kdajiyxjzhbpxbdvcycchw25s";
+            "ubs-csharp.sh" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/ubs-csharp.sh";
+              sha256 = "1xk1i2gzxpy3maa8cbzcfc29df6jn8d7wrjavarhqnpq5figljda";
             };
-            "x86_64-darwin" = {
-              url = "https://github.com/yoanbernabeu/grepai/releases/download/v${grepaiVersion}/grepai_${grepaiVersion}_darwin_amd64.tar.gz";
-              sha256 = "0mwwya2r0yl6njfq72h9s9ivnn67hjfk4rl2dcyxn06xsm1fx9nv";
+            "ubs-elixir.sh" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/ubs-elixir.sh";
+              sha256 = "1sfanq0nzcbv3524xjnvs269sn4gi442s4lpvg48s3sa8jgr6cd2";
             };
-            "aarch64-darwin" = {
-              url = "https://github.com/yoanbernabeu/grepai/releases/download/v${grepaiVersion}/grepai_${grepaiVersion}_darwin_arm64.tar.gz";
-              sha256 = "1zdwqm2bi5bxnz45vy7vzggv5914b4za2yrr21dbkl44p71blwz8";
+            "ubs-golang.sh" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/ubs-golang.sh";
+              sha256 = "1smrpfqzfxald56q80qiggxy9ir1yrz8kqbj8yw7hlid7sa1qyjw";
             };
-          };
-          grepaiSource = grepaiSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for grepai: ${prev.stdenv.hostPlatform.system}");
-
-          # beads_viewer (bv) - TUI for beads issue tracking
-          bvVersion = "0.15.2";
-          bvSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/beads_viewer/releases/download/v${bvVersion}/bv_${bvVersion}_linux_amd64.tar.gz";
-              sha256 = "0kk6lxc904j3mxxjxp7df4hq9swib8rj5srqsqayk6f5fbp7sz26";
+            "ubs-java.sh" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/ubs-java.sh";
+              sha256 = "18plk8k04y9cp2q31z1ivmq4khflf6x852i4jym0rhnpf79g4vcx";
             };
-            "aarch64-linux" = {
-              url = "https://github.com/Dicklesworthstone/beads_viewer/releases/download/v${bvVersion}/bv_${bvVersion}_linux_arm64.tar.gz";
-              sha256 = "1gj1fjs6df2i0ipvlc05wj5cq5s0lwmkcif4an5v0m6xrqkv7jab";
+            "ubs-js.sh" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/ubs-js.sh";
+              sha256 = "0l8ma829ir8x4cymlgb0ary500f0qxqkl98043rkbjlhirhbqwnl";
             };
-            "x86_64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/beads_viewer/releases/download/v${bvVersion}/bv_${bvVersion}_darwin_amd64.tar.gz";
-              sha256 = "1lpphsis977j7kva1xic0cwws0mawylp3l34fzv9s0g21imih78d";
+            "ubs-python.sh" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/ubs-python.sh";
+              sha256 = "1pjgz5svz8z1nr1bpnqf2sjndw2xpvkmyq5dmvw755aihm41n776";
             };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/beads_viewer/releases/download/v${bvVersion}/bv_${bvVersion}_darwin_arm64.tar.gz";
-              sha256 = "1jz29wn35n9pnc39gbjgqxph2x787xnqkx1y8icqfzwbnwprgpaf";
+            "ubs-ruby.sh" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/ubs-ruby.sh";
+              sha256 = "0isl3hmbwi86wsbwq742gykaqq7lay349q7dj9lbn1frphd2awq9";
+            };
+            "ubs-rust.sh" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/ubs-rust.sh";
+              sha256 = "0h2p6ap0sb99ll86h60cwfrkrrbyb2z4shpddbw7xmyxs0irh916";
+            };
+            "ubs-swift.sh" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/ubs-swift.sh";
+              sha256 = "1h79j7s5r1g9sf748l9jirhnsjscm9npwxann1fp7am7kzib5f5b";
             };
           };
-          bvSource = bvSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for bv: ${prev.stdenv.hostPlatform.system}");
-
-          # cass - coding agent session search
-          cassVersion = "0.2.2";
-          cassSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/coding_agent_session_search/releases/download/v${cassVersion}/cass-linux-amd64.tar.gz";
-              sha256 = "0cs0g447v91irv39d7kafn919aici6zw7kqck9j7h6njlkm8kr3i";
+          # Helper assets (from v5.3.2 tag)
+          ubsHelpers = {
+            "helpers/async_task_handles_csharp.py" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/async_task_handles_csharp.py";
+              sha256 = "08ihkphd7ywrlw21dfh5ac4a8bxxl4wnms8qrspkvard6lrgzvx1";
             };
-            "aarch64-linux" = {
-              url = "https://github.com/Dicklesworthstone/coding_agent_session_search/releases/download/v${cassVersion}/cass-linux-arm64.tar.gz";
-              sha256 = "1ba6bn1ajj1lss6rmvdzm4vzk5vjjhz0j24gzhzk1zbhc7mi57x2";
+            "helpers/resource_lifecycle_cpp.py" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/resource_lifecycle_cpp.py";
+              sha256 = "1a6zyzmwmzb7qvj13l2l4gzd4xd6rv59lc4rjdc4ccm28y0g5jgg";
             };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/coding_agent_session_search/releases/download/v${cassVersion}/cass-darwin-arm64.tar.gz";
-              sha256 = "0cm844ndsmjqa9j4mlz63yvi6pq4yc1xivshpm1l3dajh2q9r9vz";
+            "helpers/resource_lifecycle_csharp.py" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/resource_lifecycle_csharp.py";
+              sha256 = "0a2zx6712dbalq8db58ddgyja6dwi9maahgrrj0nfq9ykl264dba";
             };
-          };
-          cassSource = cassSources.${prev.stdenv.hostPlatform.system} or null;
-
-          # slb - Shannon Language Benchmark for LLM evaluation
-          slbVersion = "0.2.0";
-          slbSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/slb/releases/download/v${slbVersion}/slb_${slbVersion}_linux_amd64.tar.gz";
-              sha256 = "9ceed8af0ec18b425bafda9bb6b289e1e42faec8584d84c4fea529fc1ca25597";
+            "helpers/resource_lifecycle_go.go" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/resource_lifecycle_go.go";
+              sha256 = "1g9q1qchpfaf1p9vzqahr7qh5mx9k5laaq4wgrd91mrdfwn5s88h";
             };
-            "aarch64-linux" = {
-              url = "https://github.com/Dicklesworthstone/slb/releases/download/v${slbVersion}/slb_${slbVersion}_linux_arm64.tar.gz";
-              sha256 = "ba8d8ad2fdf6ffaf7556c55e5d5283893a8dfe1e30f41fc981fc3e28882e01fa";
+            "helpers/resource_lifecycle_java.py" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/resource_lifecycle_java.py";
+              sha256 = "1w9rvy1bgygp4ysw3dwi5x4k1ajai2gzjigsyv6539za34axl1f0";
             };
-            "x86_64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/slb/releases/download/v${slbVersion}/slb_${slbVersion}_darwin_amd64.tar.gz";
-              sha256 = "39ecce943d9924c555a97184ea0745751048ca0a9acc8413ee4310afe2e1bed1";
+            "helpers/resource_lifecycle_py.py" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/resource_lifecycle_py.py";
+              sha256 = "0gj8034w6z8by725nwv1vsy4wcz2pmsq73wvkyhsd3wq5ks4z20y";
             };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/slb/releases/download/v${slbVersion}/slb_${slbVersion}_darwin_arm64.tar.gz";
-              sha256 = "0898545c20c9fe867cfb713e8fe94772dfc5da60dd9eee4a1dcaaffccf86386a";
+            "helpers/resource_lifecycle_ruby.py" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/resource_lifecycle_ruby.py";
+              sha256 = "1hhxkd1cplb5fnrfm035ykplcy43jvi097pllzdy8cy8r9dwvzxy";
             };
-          };
-          slbSource = slbSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for slb: ${prev.stdenv.hostPlatform.system}");
-
-          # csctf - Chat Shared Conversation To File
-          csctfVersion = "0.4.5";
-          csctfSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/chat_shared_conversation_to_file/releases/download/v${csctfVersion}/csctf-linux-x64";
-              sha256 = "bb58bbd35de1d408b5fede47c61a7ff89038983043d8f735888d72a095b7fef3";
+            "helpers/resource_lifecycle_swift.py" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/resource_lifecycle_swift.py";
+              sha256 = "03xxmzrkd76n3gh0m3brv5fda27lynzl1lh5bg8g1ynzmj1qx9rk";
             };
-            "aarch64-linux" = {
-              url = "https://github.com/Dicklesworthstone/chat_shared_conversation_to_file/releases/download/v${csctfVersion}/csctf-linux-arm64";
-              sha256 = "3dc185dd7eb466fc6c6f77d388fd6e76628a1e1ddd3248869ae9b6792df76875";
+            "helpers/type_narrowing_csharp.py" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/type_narrowing_csharp.py";
+              sha256 = "0b51bhgsr60yczfhn8j0d3wllzpg7034vd6wmmwzr3b0cxpw3c5r";
             };
-            "x86_64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/chat_shared_conversation_to_file/releases/download/v${csctfVersion}/csctf-macos-x64";
-              sha256 = "42075d7ef82c3b17a6419a4033b7a219478ce162fb605668f0048843b06a5265";
+            "helpers/type_narrowing_kotlin.py" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/type_narrowing_kotlin.py";
+              sha256 = "0yddg1nai3f7cxi87vyic4jdvvlky6x5c2c3q9dd2jf3x21483vg";
             };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/chat_shared_conversation_to_file/releases/download/v${csctfVersion}/csctf-macos-arm64";
-              sha256 = "d5d88aeb20c13bded9e186b89a3c0d7f00705fbc658ee5a41766a84f7da90e7c";
+            "helpers/type_narrowing_rust.py" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/type_narrowing_rust.py";
+              sha256 = "0zv422w0q6x8cshw7s72674i4il50lvvi70ncdy9myyzwq6dcnim";
+            };
+            "helpers/type_narrowing_swift.py" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/type_narrowing_swift.py";
+              sha256 = "06ml047rqw5l77j1nddwp7mgzc0iriyx6xwwfzj6869rjbxbll7r";
+            };
+            "helpers/type_narrowing_ts.js" = prev.fetchurl {
+              url = "${ubsBaseUrl}/modules/helpers/type_narrowing_ts.js";
+              sha256 = "0ax3sc72d0xqzjjqfg3gmb76s2cnsvjif6qdnmdhd416rjh30vn2";
             };
           };
-          csctfSource = csctfSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for csctf: ${prev.stdenv.hostPlatform.system}");
+        in
+        prev.stdenv.mkDerivation {
+          pname = "ubs";
+          version = ubsVersion;
 
-          # brenner - Sydney Brenner research platform CLI
-          brennerVersion = "0.3.0";
-          brennerSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/brenner_bot/releases/download/v${brennerVersion}/brenner-linux-x64";
-              sha256 = "fac82298dd5daabc798aab45ab0b724d600f39e65ffddbc8a2d2f8cfc5f95cb4";
-            };
-            "aarch64-linux" = {
-              url = "https://github.com/Dicklesworthstone/brenner_bot/releases/download/v${brennerVersion}/brenner-linux-arm64";
-              sha256 = "8e359b523703e350963e4d78098c0d7ff768c7224ead6aaf47a1c4ed52f42324";
-            };
-            "x86_64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/brenner_bot/releases/download/v${brennerVersion}/brenner-darwin-x64";
-              sha256 = "fff8aa65c9ab8b193b37a1a8b7e29a732fbcacf73a2d42e631ed7553fedf7947";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/brenner_bot/releases/download/v${brennerVersion}/brenner-darwin-arm64";
-              sha256 = "e321c7063ea092a75a7a07d292b3e1949b4bbf38409c0a8a12314634384b580b";
-            };
-          };
-          brennerSource = brennerSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for brenner: ${prev.stdenv.hostPlatform.system}");
-
-          # toon - Token-Optimized Object Notation converter (JSON <-> TOON)
-          toonVersion = "0.2.1";
-          toonSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/toon_rust/releases/download/v${toonVersion}/toon-linux-amd64.tar.xz";
-              sha256 = "f547b4ae9ce241a7317f4a0d2cacfbf335ccb85d7941558f44830ecb47f65fe3";
-            };
-            "aarch64-linux" = {
-              url = "https://github.com/Dicklesworthstone/toon_rust/releases/download/v${toonVersion}/toon-linux-arm64.tar.xz";
-              sha256 = "7d3d94a9b24ff2b7d5ec60c1bc2bc3fbec750449dc619922bfd1377f74adbe2a";
-            };
-            "x86_64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/toon_rust/releases/download/v${toonVersion}/toon-darwin-amd64.tar.xz";
-              sha256 = "704c6b4113147faff8fbe1540157583d2347c34668b4bec9a0e3bba471ef582c";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/toon_rust/releases/download/v${toonVersion}/toon-darwin-arm64.tar.xz";
-              sha256 = "8bd9b439f560243525f35bca2bba117ddb6085d0d45eabc450cb29a715006ab5";
-            };
-          };
-          toonSource = toonSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for toon: ${prev.stdenv.hostPlatform.system}");
-
-          # ms - Meta Skill manager with Thompson sampling optimization
-          msVersion = "0.1.0";
-          msSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/meta_skill/releases/download/v${msVersion}/ms-${msVersion}-x86_64-unknown-linux-gnu.tar.gz";
-              sha256 = "c793ba2c37575d5799d820853cb411a40dc9ba660741fe36b557efda706c794f";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/meta_skill/releases/download/v${msVersion}/ms-${msVersion}-aarch64-apple-darwin.tar.gz";
-              sha256 = "31df557201b4466a079e218c703d83c4feb11ff9626963f04152be14ce9d95f8";
-            };
-          };
-          msSource = msSources.${prev.stdenv.hostPlatform.system} or null;
-
-          # gws - Google Workspace CLI
-          gwsVersion = "0.16.0";
-          gwsSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/googleworkspace/cli/releases/download/v${gwsVersion}/gws-x86_64-unknown-linux-musl.tar.gz";
-              sha256 = "0rppgb31mdd0vpyr8kizx3isznaark6407irim832n6dl9hlrz19";
-              dir = "gws-x86_64-unknown-linux-musl";
-            };
-            "aarch64-linux" = {
-              url = "https://github.com/googleworkspace/cli/releases/download/v${gwsVersion}/gws-aarch64-unknown-linux-musl.tar.gz";
-              sha256 = "0904pd8z56zbvffzznf7hdx7s6lb1b3cq048spihi1jpqfh86ndz";
-              dir = "gws-aarch64-unknown-linux-musl";
-            };
-            "x86_64-darwin" = {
-              url = "https://github.com/googleworkspace/cli/releases/download/v${gwsVersion}/gws-x86_64-apple-darwin.tar.gz";
-              sha256 = "07kn45p9bmzf6vv9nk18l7y8z87cqq2cwm9rm224k684c6ghh6qg";
-              dir = "gws-x86_64-apple-darwin";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/googleworkspace/cli/releases/download/v${gwsVersion}/gws-aarch64-apple-darwin.tar.gz";
-              sha256 = "0z3dbjvp4nw5fch54q2vg2q77j90ssprd3abvjvzy1hgsaadsav0";
-              dir = "gws-aarch64-apple-darwin";
-            };
-          };
-          gwsSource = gwsSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for gws: ${prev.stdenv.hostPlatform.system}");
-
-          # beads_rust (br) - fast Rust port of beads issue tracker
-          brVersion = "0.1.45";
-          brSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/beads_rust/releases/download/v${brVersion}/br-v${brVersion}-linux_amd64.tar.gz";
-              sha256 = "14g39q2lwnkisi2ckaqp0ljlr29y16r5qi3p22xqk9i3q5vs53sp";
-            };
-            "aarch64-linux" = {
-              url = "https://github.com/Dicklesworthstone/beads_rust/releases/download/v${brVersion}/br-v${brVersion}-linux_arm64.tar.gz";
-              sha256 = "1hd2kyh5ivc35iqwf12hcf08x7vpa2w0vf9rd0c3f1klrvl3z088";
-            };
-            "x86_64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/beads_rust/releases/download/v${brVersion}/br-v${brVersion}-darwin_amd64.tar.gz";
-              sha256 = "0hd7m4fgja7mwvz4vwg7rxiraq15qvlvikclz2kjjpi0vbhaz287";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/beads_rust/releases/download/v${brVersion}/br-v${brVersion}-darwin_arm64.tar.gz";
-              sha256 = "1c5kvmbmzywb0a4ri1v0zxca92vhnfvls1ncjd60fkawkq3shkc9";
-            };
-          };
-          brSource = brSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for br: ${prev.stdenv.hostPlatform.system}");
-
-          # ntm - Named Tmux Manager for AI coding agent coordination
-          ntmVersion = "1.8.0";
-          ntmSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/ntm/releases/download/v${ntmVersion}/ntm_${ntmVersion}_linux_amd64.tar.gz";
-              sha256 = "1ffpi7jp9a1bb5r6hafxjyhhj6smzblrsf0d147gzqjj7nb9kvl6";
-            };
-            "aarch64-linux" = {
-              url = "https://github.com/Dicklesworthstone/ntm/releases/download/v${ntmVersion}/ntm_${ntmVersion}_linux_arm64.tar.gz";
-              sha256 = "1wj32kk05xix0fg694wnanx8ja2h3iiw4886rwhj23mll0hyss70";
-            };
-            "x86_64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/ntm/releases/download/v${ntmVersion}/ntm_${ntmVersion}_darwin_all.tar.gz";
-              sha256 = "1iq02h26whh7xcp8r3fazfjzphfmhdj8jh3kp9ydq14m5fxhn2az";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/ntm/releases/download/v${ntmVersion}/ntm_${ntmVersion}_darwin_all.tar.gz";
-              sha256 = "1iq02h26whh7xcp8r3fazfjzphfmhdj8jh3kp9ydq14m5fxhn2az";
-            };
-          };
-          ntmSource = ntmSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for ntm: ${prev.stdenv.hostPlatform.system}");
-
-          # dcg - destructive command guard
-          dcgVersion = "0.4.0";
-          dcgSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/destructive_command_guard/releases/download/v${dcgVersion}/dcg-x86_64-unknown-linux-gnu.tar.xz";
-              sha256 = "1704a533f0e40ed12bac3c13273ac1e095e20c3eebed50cc6711f7073eaa505c";
-            };
-            "aarch64-linux" = {
-              url = "https://github.com/Dicklesworthstone/destructive_command_guard/releases/download/v${dcgVersion}/dcg-aarch64-unknown-linux-gnu.tar.xz";
-              sha256 = "06d9d6358a470a1934265f95d0a1df95745e72cf9984a45fd3e373593b6bd0af";
-            };
-            "x86_64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/destructive_command_guard/releases/download/v${dcgVersion}/dcg-x86_64-apple-darwin.tar.xz";
-              sha256 = "d843a97fa6eba1b69d287afa28fb9bfe4ef22d1539da786166237c4869ee93fa";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/destructive_command_guard/releases/download/v${dcgVersion}/dcg-aarch64-apple-darwin.tar.xz";
-              sha256 = "2a0d594f1ec54b1a9453c376c4a9c6277ef548c869f60bac46cbd22928251e83";
-            };
-          };
-          dcgSource = dcgSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for dcg: ${prev.stdenv.hostPlatform.system}");
-
-          # caam - coding agent account manager (instant auth switching)
-          caamVersion = "0.1.11";
-          caamSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/coding_agent_account_manager/releases/download/v${caamVersion}/caam_${caamVersion}_linux_amd64.tar.gz";
-              sha256 = "e0a4e7e3e27c6b3e4f36f7e69ac23f3d59135702d713109de4a4431422a02845";
-            };
-            "aarch64-linux" = {
-              url = "https://github.com/Dicklesworthstone/coding_agent_account_manager/releases/download/v${caamVersion}/caam_${caamVersion}_linux_arm64.tar.gz";
-              sha256 = "65e7808cd8d90e06ba10bb755f728ac55c4ff2c97f4bc50b7af8cf56b0e2f242";
-            };
-            "x86_64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/coding_agent_account_manager/releases/download/v${caamVersion}/caam_${caamVersion}_darwin_amd64.tar.gz";
-              sha256 = "dd89be148a8a9c4dd697df296403c00db302ed458fd93e89bcd83f452711478f";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/coding_agent_account_manager/releases/download/v${caamVersion}/caam_${caamVersion}_darwin_arm64.tar.gz";
-              sha256 = "3863fb2ddfde51e4e6bded0498c933e0589487ae8a2211b216312840d242a205";
-            };
-          };
-          caamSource = caamSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for caam: ${prev.stdenv.hostPlatform.system}");
-
-          # agent-browser - browser automation CLI for AI agents
-          agentBrowserVersion = "0.20.13";
-          agentBrowserSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/vercel-labs/agent-browser/releases/download/v${agentBrowserVersion}/agent-browser-linux-x64";
-              sha256 = "16dds3b3l20s42v77j67rxapg3ij1lrhvwgk37dcfpxlq92vmi1m";
-            };
-            "aarch64-linux" = {
-              url = "https://github.com/vercel-labs/agent-browser/releases/download/v${agentBrowserVersion}/agent-browser-linux-arm64";
-              sha256 = "11m8j89iimadqjsj9ivpp4yr8f1l5hikz0la4mfsd10c3ikpknzr";
-            };
-            "x86_64-darwin" = {
-              url = "https://github.com/vercel-labs/agent-browser/releases/download/v${agentBrowserVersion}/agent-browser-darwin-x64";
-              sha256 = "0w4jbldrhc7n757n525jgnsc0x361qfxay3vj3m2pv4ff0jy81cv";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/vercel-labs/agent-browser/releases/download/v${agentBrowserVersion}/agent-browser-darwin-arm64";
-              sha256 = "1p229rnqqndhr4id89rs5m51vc68wia8q3ny1w7xhk7vmimj5g45";
-            };
-          };
-          agentBrowserSource = agentBrowserSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for agent-browser: ${prev.stdenv.hostPlatform.system}");
-
-          # pi - prompt injection detection agent (Rust)
-          piVersion = "0.1.9";
-          piSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/pi_agent_rust/releases/download/v${piVersion}/pi-linux-amd64.tar.xz";
-              sha256 = "1m3fhwv5igx2sphxkzh8m8zww1wywsjcvkgzsak0dkpl2bhg09xn";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/pi_agent_rust/releases/download/v${piVersion}/pi-darwin-arm64.tar.xz";
-              sha256 = "0ds4xa8j01r3f5ncnmc87rj1114aq657gzww8xd8lsvl71lfhrf4";
-            };
-          };
-          piSource = piSources.${prev.stdenv.hostPlatform.system} or null;
-
-          # xf - cross-format file converter
-          xfVersion = "0.2.0";
-          xfSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/xf/releases/download/v${xfVersion}/xf-x86_64-unknown-linux-gnu.tar.gz";
-              sha256 = "e8de166f4464ec46ae6b38d89194e5312f0cce06ae5398df48527d26d5bbe299";
-            };
-            "x86_64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/xf/releases/download/v${xfVersion}/xf-x86_64-apple-darwin.tar.gz";
-              sha256 = "c85c11d4be13fdda3588aeb6d9d5ff62aac150c60e9f1253c2c710882e05b2ce";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/xf/releases/download/v${xfVersion}/xf-aarch64-apple-darwin.tar.gz";
-              sha256 = "e90a04cb49e0910766b573d41338779ca22a6c29076a211eaa7148b637eb1674";
-            };
-          };
-          xfSource = xfSources.${prev.stdenv.hostPlatform.system} or null;
-
-          # mcp-agent-mail - Rust replacement for Python mcp_agent_mail
-          mcpAgentMailVersion = "0.2.7";
-          mcpAgentMailSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/mcp_agent_mail_rust/releases/download/v${mcpAgentMailVersion}/mcp-agent-mail-x86_64-unknown-linux-gnu.tar.gz";
-              sha256 = "1f6a08z138bmyz5lqnvlbyy5cjb8lmjkz4pwyy1dv8rs1lfy8sjs";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/mcp_agent_mail_rust/releases/download/v${mcpAgentMailVersion}/mcp-agent-mail-aarch64-apple-darwin.tar.gz";
-              sha256 = "0rp0r4h9g7pv5xyrjd99mf43dp4jldiq29yaw4zw5y9ym9xmx9x3";
-            };
-          };
-          mcpAgentMailSource = mcpAgentMailSources.${prev.stdenv.hostPlatform.system} or null;
-
-          # casr - cross agent session resumer
-          casrVersion = "0.1.1";
-          casrSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/cross_agent_session_resumer/releases/download/v${casrVersion}/casr-x86_64-unknown-linux-musl.tar.xz";
-              sha256 = "7ae074154c7de4febd1346f0173e155025e42c0c5c19ab72fc7fe3f68df984ec";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/cross_agent_session_resumer/releases/download/v${casrVersion}/casr-aarch64-apple-darwin.tar.xz";
-              sha256 = "add7991d676f378804ff414384ea083d43bf375277de828d96bf3b8e7a309e4d";
-            };
-          };
-          casrSource = casrSources.${prev.stdenv.hostPlatform.system} or null;
-
-          # s2p - source to prompt TUI (bare binary, no tarball)
-          s2pVersion = "0.3.2";
-          s2pSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/source_to_prompt_tui/releases/download/v${s2pVersion}/s2p-linux-x64";
-              sha256 = "0f1q10b1bffs9c0hsp5glljdc7qi959j3wg7jf0mkcflr6lbhydw";
-            };
-            "aarch64-linux" = {
-              url = "https://github.com/Dicklesworthstone/source_to_prompt_tui/releases/download/v${s2pVersion}/s2p-linux-arm64";
-              sha256 = "13bi0rsc7am8mq6ix2qw22m8hbibrj3wrs1g4mxrkayldj456yqb";
-            };
-            "x86_64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/source_to_prompt_tui/releases/download/v${s2pVersion}/s2p-macos-x64";
-              sha256 = "0cgd8c55zcm7d9s4pi55144h322kiwl2bglfvhi687br3xy46s0d";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/Dicklesworthstone/source_to_prompt_tui/releases/download/v${s2pVersion}/s2p-macos-arm64";
-              sha256 = "1j70lj8gkkvl8fnxfgqn7i10djhw6zg7z82dx9wf17crqfw20j4w";
-            };
-          };
-          s2pSource = s2pSources.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system for s2p: ${prev.stdenv.hostPlatform.system}");
-
-          # pt - process triage (intelligent process termination)
-          ptVersion = "2.0.5";
-          ptSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/process_triage/releases/download/v${ptVersion}/pt-core-linux-x86_64-${ptVersion}.tar.gz";
-              sha256 = "081wfy03dwak5sijrs9wmbs9yjsr0pfvlmh5lmvvg1zy8ppb9jjz";
-            };
-          };
-          ptSource = ptSources.${prev.stdenv.hostPlatform.system} or null;
-
-          # rch - remote compilation helper
-          rchVersion = "1.0.10";
-          rchSources = {
-            "x86_64-linux" = {
-              url = "https://github.com/Dicklesworthstone/remote_compilation_helper/releases/download/v${rchVersion}/rch-v${rchVersion}-x86_64-unknown-linux-gnu.tar.gz";
-              sha256 = "0kv9wrfx5y9qlx5c6y8zjlc2dp1aw22d6l2xd8rncdm7kw4qlqhd";
-            };
-          };
-          rchSource = rchSources.${prev.stdenv.hostPlatform.system} or null;
-        in {
-          # grepai - semantic code search for AI coding assistants
-          grepai = prev.stdenv.mkDerivation {
-            pname = "grepai";
-            version = grepaiVersion;
-
-            src = prev.fetchurl {
-              url = grepaiSource.url;
-              sha256 = grepaiSource.sha256;
-            };
-
-            sourceRoot = ".";
-
-            nativeBuildInputs = [ prev.gnutar ];
-
-            unpackPhase = ''
-              tar xzf $src
-            '';
-
-            installPhase = ''
-              mkdir -p $out/bin
-              cp grepai $out/bin/
-              chmod +x $out/bin/grepai
-            '';
-
-            meta = with prev.lib; {
-              description = "Semantic code search CLI tool for AI coding assistants";
-              homepage = "https://github.com/yoanbernabeu/grepai";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
-          # bv - beads viewer TUI for issue tracking
-          beads-viewer = prev.stdenv.mkDerivation {
-            pname = "beads-viewer";
-            version = bvVersion;
-
-            src = prev.fetchurl {
-              url = bvSource.url;
-              sha256 = bvSource.sha256;
-            };
-
-            sourceRoot = ".";
-
-            nativeBuildInputs = [ prev.gnutar ];
-
-            unpackPhase = ''
-              tar xzf $src
-            '';
-
-            installPhase = ''
-              mkdir -p $out/bin
-              cp bv $out/bin/
-              chmod +x $out/bin/bv
-            '';
-
-            meta = with prev.lib; {
-              description = "Elegant TUI for the Beads issue tracking system";
-              homepage = "https://github.com/Dicklesworthstone/beads_viewer";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
+          src = prev.fetchurl {
+            url = "${ubsBaseUrl}/ubs";
+            sha256 = "5a1765f05029e571e9d7da71ebb972b777e3ecbdafe540cdd17bd54eaf543132";
           };
 
-          # ubs - ultimate bug scanner for AI-assisted code quality
-          ubs = let
-            ubsVersion = "5.0.6";
-            ubsBaseUrl = "https://raw.githubusercontent.com/Dicklesworthstone/ultimate_bug_scanner/v${ubsVersion}";
-            # Language modules (from v5.0.6 tag)
-            ubsModules = {
-              "ubs-js.sh" = prev.fetchurl { url = "${ubsBaseUrl}/modules/ubs-js.sh"; sha256 = "1h1q58rx907kxbbjksbfg0ic2irrvblxxmjmgwkrckbriqqqja7r"; };
-              "ubs-python.sh" = prev.fetchurl { url = "${ubsBaseUrl}/modules/ubs-python.sh"; sha256 = "0hwsdkfpkxvpzb0lggkzk8i95vjnhs3vy5yb7r0hwavs7bwplsg7"; };
-              "ubs-cpp.sh" = prev.fetchurl { url = "${ubsBaseUrl}/modules/ubs-cpp.sh"; sha256 = "0a3gira5g344dl8r1xp5968wi569hcg4qx8q9nr2xz5q7hz22smc"; };
-              "ubs-rust.sh" = prev.fetchurl { url = "${ubsBaseUrl}/modules/ubs-rust.sh"; sha256 = "1w42wxqs18dvgvaa8w0630xsmk3psrix5fmr1358mhcccgsga3aw"; };
-              "ubs-golang.sh" = prev.fetchurl { url = "${ubsBaseUrl}/modules/ubs-golang.sh"; sha256 = "1ipl3zi3cqypgqv7qvnfmbrsi6567l5wv9njmp44chk8ybldcmxi"; };
-              "ubs-java.sh" = prev.fetchurl { url = "${ubsBaseUrl}/modules/ubs-java.sh"; sha256 = "0mkjndc64xvy0jblf1myk91w245bms45ha8dz3jlb78rppb0n4kb"; };
-              "ubs-ruby.sh" = prev.fetchurl { url = "${ubsBaseUrl}/modules/ubs-ruby.sh"; sha256 = "01alh2fqrwks4ljzz6jc09b6syyvifncxm433b876j2g2xmab41l"; };
-              "ubs-swift.sh" = prev.fetchurl { url = "${ubsBaseUrl}/modules/ubs-swift.sh"; sha256 = "0alaih98hngf7yd7vz70afpfqr28zxq7rbsfr6i9cpvj8apc4l5k"; };
-            };
-            # Helper assets (from v5.0.6 tag)
-            ubsHelpers = {
-              "helpers/resource_lifecycle_py.py" = prev.fetchurl { url = "${ubsBaseUrl}/modules/helpers/resource_lifecycle_py.py"; sha256 = "0gj8034w6z8by725nwv1vsy4wcz2pmsq73wvkyhsd3wq5ks4z20y"; };
-              "helpers/resource_lifecycle_go.go" = prev.fetchurl { url = "${ubsBaseUrl}/modules/helpers/resource_lifecycle_go.go"; sha256 = "1g9q1qchpfaf1p9vzqahr7qh5mx9k5laaq4wgrd91mrdfwn5s88h"; };
-              "helpers/resource_lifecycle_java.py" = prev.fetchurl { url = "${ubsBaseUrl}/modules/helpers/resource_lifecycle_java.py"; sha256 = "1w9rvy1bgygp4ysw3dwi5x4k1ajai2gzjigsyv6539za34axl1f0"; };
-              "helpers/type_narrowing_ts.js" = prev.fetchurl { url = "${ubsBaseUrl}/modules/helpers/type_narrowing_ts.js"; sha256 = "0cgn5chgmar758dg4rkqq7nc8g1a89zsd8l0hy3dv689zgsfqag1"; };
-              "helpers/type_narrowing_rust.py" = prev.fetchurl { url = "${ubsBaseUrl}/modules/helpers/type_narrowing_rust.py"; sha256 = "0zv422w0q6x8cshw7s72674i4il50lvvi70ncdy9myyzwq6dcnim"; };
-              "helpers/type_narrowing_kotlin.py" = prev.fetchurl { url = "${ubsBaseUrl}/modules/helpers/type_narrowing_kotlin.py"; sha256 = "0yddg1nai3f7cxi87vyic4jdvvlky6x5c2c3q9dd2jf3x21483vg"; };
-              "helpers/type_narrowing_swift.py" = prev.fetchurl { url = "${ubsBaseUrl}/modules/helpers/type_narrowing_swift.py"; sha256 = "06ml047rqw5l77j1nddwp7mgzc0iriyx6xwwfzj6869rjbxbll7r"; };
-            };
-          in prev.stdenv.mkDerivation {
-            pname = "ubs";
-            version = ubsVersion;
+          dontUnpack = true;
 
-            src = prev.fetchurl {
-              url = "${ubsBaseUrl}/ubs";
-              sha256 = "ebb31bf412a409a19a060f2587c2ea02f185c0bf695204db6c73ef7560d377ed";
-            };
+          nativeBuildInputs = [ prev.makeWrapper ];
 
-            dontUnpack = true;
+          installPhase = ''
+            mkdir -p $out/bin
+            mkdir -p $out/share/ubs/modules/helpers
 
-            nativeBuildInputs = [ prev.makeWrapper ];
-
-            installPhase = ''
-              mkdir -p $out/bin
-              mkdir -p $out/share/ubs/modules/helpers
-
-              # Install language modules (non-executable to prevent patchShebangs
-              # from rewriting shebangs, which would break UBS checksum verification)
-              ${prev.lib.concatStringsSep "\n" (prev.lib.mapAttrsToList (name: src: ''
+            # Install language modules (non-executable to prevent patchShebangs
+            # from rewriting shebangs, which would break UBS checksum verification)
+            ${prev.lib.concatStringsSep "\n" (
+              prev.lib.mapAttrsToList (name: src: ''
                 cp ${src} $out/share/ubs/modules/${name}
-              '') ubsModules)}
+              '') ubsModules
+            )}
 
-              # Install helper assets
-              ${prev.lib.concatStringsSep "\n" (prev.lib.mapAttrsToList (name: src: ''
+            # Install helper assets
+            ${prev.lib.concatStringsSep "\n" (
+              prev.lib.mapAttrsToList (name: src: ''
                 cp ${src} $out/share/ubs/modules/${name}
-              '') ubsHelpers)}
+              '') ubsHelpers
+            )}
 
-              cp $src $out/bin/.ubs-unwrapped
-              chmod +x $out/bin/.ubs-unwrapped
-              wrapProgram $out/bin/.ubs-unwrapped \
-                --prefix PATH : ${prev.lib.makeBinPath [
+            cp $src $out/bin/.ubs-unwrapped
+            chmod +x $out/bin/.ubs-unwrapped
+            wrapProgram $out/bin/.ubs-unwrapped \
+              --prefix PATH : ${
+                prev.lib.makeBinPath [
                   prev.bash
                   prev.coreutils
                   prev.gnugrep
@@ -545,41 +666,49 @@
                   prev.ast-grep
                   prev.typos
                   prev.python3
-                ]}
+                ]
+              }
 
-              # UBS checks $1 for subcommands (doctor, sessions) before parsing
-              # flags, so --module-dir must come AFTER any subcommand, not before.
-              # Skip injecting for 'sessions' mode which doesn't use modules.
-              cat > $out/bin/ubs <<'WRAPPER'
-              #!/usr/bin/env bash
-              if [[ "''${1:-}" == "sessions" || "''${1:-}" == "session-log" ]]; then
-                exec "PLACEHOLDER_BIN" "$@"
-              else
-                exec "PLACEHOLDER_BIN" "$@" --module-dir="PLACEHOLDER_DIR"
-              fi
-              WRAPPER
-              substituteInPlace $out/bin/ubs \
-                --replace-quiet "PLACEHOLDER_BIN" "$out/bin/.ubs-unwrapped" \
-                --replace-quiet "PLACEHOLDER_DIR" "$out/share/ubs/modules"
-              chmod +x $out/bin/ubs
-            '';
+            # UBS checks $1 for subcommands (doctor, sessions) before parsing
+            # flags, so --module-dir must come AFTER any subcommand, not before.
+            # Skip injecting for 'sessions' mode which doesn't use modules.
+            cat > $out/bin/ubs <<'WRAPPER'
+            #!/usr/bin/env bash
+            if [[ "''${1:-}" == "sessions" || "''${1:-}" == "session-log" ]]; then
+              exec "PLACEHOLDER_BIN" "$@"
+            else
+              exec "PLACEHOLDER_BIN" "$@" --module-dir="PLACEHOLDER_DIR"
+            fi
+            WRAPPER
+            substituteInPlace $out/bin/ubs \
+              --replace-quiet "PLACEHOLDER_BIN" "$out/bin/.ubs-unwrapped" \
+              --replace-quiet "PLACEHOLDER_DIR" "$out/share/ubs/modules"
+            chmod +x $out/bin/ubs
+          '';
 
-            # Make modules executable after fixupPhase (patchShebangs) has run,
-            # preserving original shebangs so UBS checksum verification passes.
-            postFixup = ''
-              chmod +x $out/share/ubs/modules/ubs-*.sh
-            '';
+          # Make modules executable after fixupPhase (patchShebangs) has run,
+          # preserving original shebangs so UBS checksum verification passes.
+          postFixup = ''
+            chmod +x $out/share/ubs/modules/ubs-*.sh
+          '';
 
-            meta = with prev.lib; {
-              description = "AI-native code quality scanner detecting 1000+ bug patterns";
-              homepage = "https://github.com/Dicklesworthstone/ultimate_bug_scanner";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
+          meta = with prev.lib; {
+            description = "AI-native code quality scanner detecting 1000+ bug patterns";
+            homepage = "https://github.com/Dicklesworthstone/ultimate_bug_scanner";
+            license = licenses.mit;
+            platforms = [
+              "x86_64-linux"
+              "aarch64-linux"
+              "x86_64-darwin"
+              "aarch64-darwin"
+            ];
           };
+        };
 
-          # cass - coding agent session search TUI (pre-built binary)
-          cass = if cassSource != null then prev.stdenv.mkDerivation {
+      # cass - coding agent session search TUI (pre-built binary)
+      cass =
+        if cassSource != null then
+          prev.stdenv.mkDerivation {
             pname = "cass";
             version = cassVersion;
 
@@ -590,14 +719,19 @@
 
             sourceRoot = ".";
 
-            nativeBuildInputs = [ prev.gnutar ]
-              ++ prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
+            nativeBuildInputs = [
+              prev.gnutar
+            ]
+            ++ prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
 
-            buildInputs = prev.lib.optionals prev.stdenv.isLinux (with prev; [
-              openssl
-              onnxruntime
-              stdenv.cc.cc.lib  # libstdc++
-            ]);
+            buildInputs = prev.lib.optionals prev.stdenv.isLinux (
+              with prev;
+              [
+                openssl
+                onnxruntime
+                stdenv.cc.cc.lib # libstdc++
+              ]
+            );
 
             unpackPhase = ''
               tar xzf $src
@@ -613,126 +747,154 @@
               description = "Cross-agent session search - index and search AI coding agent conversations";
               homepage = "https://github.com/Dicklesworthstone/coding_agent_session_search";
               license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+              platforms = [
+                "x86_64-linux"
+                "aarch64-linux"
+                "aarch64-darwin"
+              ];
             };
-          } else null;
+          }
+        else
+          null;
 
-          # slb - Shannon Language Benchmark for LLM evaluation
-          slb = prev.stdenv.mkDerivation {
-            pname = "slb";
-            version = slbVersion;
+      # slb - Shannon Language Benchmark for LLM evaluation
+      slb = prev.stdenv.mkDerivation {
+        pname = "slb";
+        version = slbVersion;
 
-            src = prev.fetchurl {
-              url = slbSource.url;
-              sha256 = slbSource.sha256;
-            };
+        src = prev.fetchurl {
+          url = slbSource.url;
+          sha256 = slbSource.sha256;
+        };
 
-            sourceRoot = ".";
+        sourceRoot = ".";
 
-            nativeBuildInputs = [ prev.gnutar ];
+        nativeBuildInputs = [ prev.gnutar ];
 
-            unpackPhase = ''
-              tar xzf $src
-            '';
+        unpackPhase = ''
+          tar xzf $src
+        '';
 
-            installPhase = ''
-              mkdir -p $out/bin
-              cp slb $out/bin/
-              chmod +x $out/bin/slb
-            '';
+        installPhase = ''
+          mkdir -p $out/bin
+          cp slb $out/bin/
+          chmod +x $out/bin/slb
+        '';
 
-            meta = with prev.lib; {
-              description = "Shannon Language Benchmark - evaluate LLM performance with information-theoretic metrics";
-              homepage = "https://github.com/Dicklesworthstone/slb";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
+        meta = with prev.lib; {
+          description = "Shannon Language Benchmark - evaluate LLM performance with information-theoretic metrics";
+          homepage = "https://github.com/Dicklesworthstone/slb";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
 
-          # csctf - Chat Shared Conversation To File (bare binary, no tarball)
-          csctf = prev.stdenv.mkDerivation {
-            pname = "csctf";
-            version = csctfVersion;
+      # csctf - Chat Shared Conversation To File (bare binary, no tarball)
+      csctf = prev.stdenv.mkDerivation {
+        pname = "csctf";
+        version = csctfVersion;
 
-            src = prev.fetchurl {
-              url = csctfSource.url;
-              sha256 = csctfSource.sha256;
-            };
+        src = prev.fetchurl {
+          url = csctfSource.url;
+          sha256 = csctfSource.sha256;
+        };
 
-            dontUnpack = true;
+        dontUnpack = true;
 
-            installPhase = ''
-              mkdir -p $out/bin
-              cp $src $out/bin/csctf
-              chmod +x $out/bin/csctf
-            '';
+        installPhase = ''
+          mkdir -p $out/bin
+          cp $src $out/bin/csctf
+          chmod +x $out/bin/csctf
+        '';
 
-            meta = with prev.lib; {
-              description = "Convert AI chat share links to clean Markdown and HTML transcripts";
-              homepage = "https://github.com/Dicklesworthstone/chat_shared_conversation_to_file";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
+        meta = with prev.lib; {
+          description = "Convert AI chat share links to clean Markdown and HTML transcripts";
+          homepage = "https://github.com/Dicklesworthstone/chat_shared_conversation_to_file";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
 
-          # brenner - Sydney Brenner research platform CLI (bare binary)
-          brenner = prev.stdenv.mkDerivation {
-            pname = "brenner";
-            version = brennerVersion;
+      # brenner - Sydney Brenner research platform CLI (bare binary)
+      brenner = prev.stdenv.mkDerivation {
+        pname = "brenner";
+        version = brennerVersion;
 
-            src = prev.fetchurl {
-              url = brennerSource.url;
-              sha256 = brennerSource.sha256;
-            };
+        src = prev.fetchurl {
+          url = brennerSource.url;
+          sha256 = brennerSource.sha256;
+        };
 
-            dontUnpack = true;
+        dontUnpack = true;
 
-            installPhase = ''
-              mkdir -p $out/bin
-              cp $src $out/bin/brenner
-              chmod +x $out/bin/brenner
-            '';
+        installPhase = ''
+          mkdir -p $out/bin
+          cp $src $out/bin/brenner
+          chmod +x $out/bin/brenner
+        '';
 
-            meta = with prev.lib; {
-              description = "Sydney Brenner research platform CLI for AI-assisted scientific inquiry";
-              homepage = "https://github.com/Dicklesworthstone/brenner_bot";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
+        meta = with prev.lib; {
+          description = "Sydney Brenner research platform CLI for AI-assisted scientific inquiry";
+          homepage = "https://github.com/Dicklesworthstone/brenner_bot";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
 
-          # toon - Token-Optimized Object Notation converter
-          toon = prev.stdenv.mkDerivation {
-            pname = "toon";
-            version = toonVersion;
+      # toon - Token-Optimized Object Notation converter
+      toon = prev.stdenv.mkDerivation {
+        pname = "toon";
+        version = toonVersion;
 
-            src = prev.fetchurl {
-              url = toonSource.url;
-              sha256 = toonSource.sha256;
-            };
+        src = prev.fetchurl {
+          url = toonSource.url;
+          sha256 = toonSource.sha256;
+        };
 
-            sourceRoot = ".";
+        sourceRoot = ".";
 
-            unpackPhase = ''
-              ${prev.xz}/bin/xz -d < $src | tar xf -
-            '';
+        unpackPhase = ''
+          ${prev.xz}/bin/xz -d < $src | tar xf -
+        '';
 
-            installPhase = ''
-              mkdir -p $out/bin
-              cp toon $out/bin/
-              chmod +x $out/bin/toon
-            '';
+        installPhase = ''
+          mkdir -p $out/bin
+          cp toon $out/bin/
+          chmod +x $out/bin/toon
+        '';
 
-            meta = with prev.lib; {
-              description = "Token-Optimized Object Notation - convert between JSON and TOON formats";
-              homepage = "https://github.com/Dicklesworthstone/toon_rust";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
+        meta = with prev.lib; {
+          description = "Token-Optimized Object Notation - convert between JSON and TOON formats";
+          homepage = "https://github.com/Dicklesworthstone/toon_rust";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
 
-          # ms - Meta Skill manager with Thompson sampling
-          meta-skill = if msSource != null then prev.stdenv.mkDerivation {
+      # ms - Meta Skill manager with Thompson sampling
+      meta-skill =
+        if msSource != null then
+          prev.stdenv.mkDerivation {
             pname = "meta-skill";
             version = msVersion;
 
@@ -743,14 +905,19 @@
 
             sourceRoot = ".";
 
-            nativeBuildInputs = [ prev.gnutar ]
-              ++ prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
+            nativeBuildInputs = [
+              prev.gnutar
+            ]
+            ++ prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
 
-            buildInputs = prev.lib.optionals prev.stdenv.isLinux (with prev; [
-              openssl
-              zlib
-              stdenv.cc.cc.lib
-            ]);
+            buildInputs = prev.lib.optionals prev.stdenv.isLinux (
+              with prev;
+              [
+                openssl
+                zlib
+                stdenv.cc.cc.lib
+              ]
+            );
 
             unpackPhase = ''
               tar xzf $src
@@ -766,188 +933,224 @@
               description = "Skill management with Thompson sampling optimization";
               homepage = "https://github.com/Dicklesworthstone/meta_skill";
               license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-darwin" ];
+              platforms = [
+                "x86_64-linux"
+                "aarch64-darwin"
+              ];
             };
-          } else null;
+          }
+        else
+          null;
 
-          # gws - Google Workspace CLI
-          gws = prev.stdenv.mkDerivation {
-            pname = "gws";
-            version = gwsVersion;
+      # gws - Google Workspace CLI
+      gws = prev.stdenv.mkDerivation {
+        pname = "gws";
+        version = gwsVersion;
 
-            src = prev.fetchurl {
-              url = gwsSource.url;
-              sha256 = gwsSource.sha256;
-            };
+        src = prev.fetchurl {
+          url = gwsSource.url;
+          sha256 = gwsSource.sha256;
+        };
 
-            sourceRoot = gwsSource.dir;
+        sourceRoot = gwsSource.dir;
 
-            nativeBuildInputs = [ prev.gnutar ];
+        nativeBuildInputs = [ prev.gnutar ];
 
-            installPhase = ''
-              mkdir -p $out/bin
-              cp gws $out/bin/
-              chmod +x $out/bin/gws
-            '';
+        installPhase = ''
+          mkdir -p $out/bin
+          cp gws $out/bin/
+          chmod +x $out/bin/gws
+        '';
 
-            meta = with prev.lib; {
-              description = "Google Workspace CLI for Drive, Gmail, Calendar, Sheets, Docs, Chat, Admin";
-              homepage = "https://github.com/googleworkspace/cli";
-              license = licenses.asl20;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
+        meta = with prev.lib; {
+          description = "Google Workspace CLI for Drive, Gmail, Calendar, Sheets, Docs, Chat, Admin";
+          homepage = "https://github.com/googleworkspace/cli";
+          license = licenses.asl20;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
 
-          # br - beads_rust, fast Rust port of beads issue tracker
-          beads-rust = prev.stdenv.mkDerivation {
-            pname = "beads-rust";
-            version = brVersion;
+      # br - beads_rust, fast Rust port of beads issue tracker
+      beads-rust = prev.stdenv.mkDerivation {
+        pname = "beads-rust";
+        version = brVersion;
 
-            src = prev.fetchurl {
-              url = brSource.url;
-              sha256 = brSource.sha256;
-            };
+        src = prev.fetchurl {
+          url = brSource.url;
+          sha256 = brSource.sha256;
+        };
 
-            sourceRoot = ".";
+        sourceRoot = ".";
 
-            nativeBuildInputs = [ prev.gnutar ];
+        nativeBuildInputs = [ prev.gnutar ];
 
-            unpackPhase = ''
-              tar xzf $src
-            '';
+        unpackPhase = ''
+          tar xzf $src
+        '';
 
-            installPhase = ''
-              mkdir -p $out/bin
-              cp br $out/bin/
-              chmod +x $out/bin/br
-              ln -s $out/bin/br $out/bin/bd
-            '';
+        installPhase = ''
+          mkdir -p $out/bin
+          cp br $out/bin/
+          chmod +x $out/bin/br
+          ln -s $out/bin/br $out/bin/bd
+        '';
 
-            meta = with prev.lib; {
-              description = "Fast Rust port of beads issue tracker with SQLite backend";
-              homepage = "https://github.com/Dicklesworthstone/beads_rust";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
+        meta = with prev.lib; {
+          description = "Fast Rust port of beads issue tracker with SQLite backend";
+          homepage = "https://github.com/Dicklesworthstone/beads_rust";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
 
-          # ntm - Named Tmux Manager for AI coding agent coordination
-          ntm = prev.stdenv.mkDerivation {
-            pname = "ntm";
-            version = ntmVersion;
+      # ntm - Named Tmux Manager for AI coding agent coordination
+      ntm = prev.stdenv.mkDerivation {
+        pname = "ntm";
+        version = ntmVersion;
 
-            src = prev.fetchurl {
-              url = ntmSource.url;
-              sha256 = ntmSource.sha256;
-            };
+        src = prev.fetchurl {
+          url = ntmSource.url;
+          sha256 = ntmSource.sha256;
+        };
 
-            sourceRoot = ".";
+        sourceRoot = ".";
 
-            nativeBuildInputs = [ prev.gnutar ];
+        nativeBuildInputs = [ prev.gnutar ];
 
-            unpackPhase = ''
-              tar xzf $src
-            '';
+        unpackPhase = ''
+          tar xzf $src
+        '';
 
-            installPhase = ''
-              mkdir -p $out/bin
-              cp ntm $out/bin/
-              chmod +x $out/bin/ntm
-            '';
+        installPhase = ''
+          mkdir -p $out/bin
+          cp ntm $out/bin/
+          chmod +x $out/bin/ntm
+        '';
 
-            meta = with prev.lib; {
-              description = "Named Tmux Manager for spawning and coordinating AI coding agents";
-              homepage = "https://github.com/Dicklesworthstone/ntm";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
+        meta = with prev.lib; {
+          description = "Named Tmux Manager for spawning and coordinating AI coding agents";
+          homepage = "https://github.com/Dicklesworthstone/ntm";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
 
-          # ru - repo updater for syncing GitHub repositories
-          repo-updater = prev.stdenv.mkDerivation {
-            pname = "repo-updater";
-            version = "1.2.1";
+      # ru - repo updater for syncing GitHub repositories
+      repo-updater = prev.stdenv.mkDerivation {
+        pname = "repo-updater";
+        version = "1.3.1";
 
-            src = prev.fetchurl {
-              url = "https://github.com/Dicklesworthstone/repo_updater/releases/download/v1.2.1/ru";
-              sha256 = "7dc465cc5a47102b68a983202b1026d451d767d76c969fe03c6eac1726bf3709";
-            };
+        src = prev.fetchurl {
+          url = "https://github.com/Dicklesworthstone/repo_updater/releases/download/v1.3.1/ru";
+          sha256 = "6ae3ae2d850d26c0ad82e3b5e713338f74f2bfd483691e4d09d9d75e00a79b3a";
+        };
 
-            dontUnpack = true;
+        dontUnpack = true;
 
-            nativeBuildInputs = [ prev.makeWrapper ];
+        nativeBuildInputs = [ prev.makeWrapper ];
 
-            installPhase = ''
-              mkdir -p $out/bin
-              cp $src $out/bin/ru
-              chmod +x $out/bin/ru
-              wrapProgram $out/bin/ru \
-                --prefix PATH : ${prev.lib.makeBinPath [
-                  prev.bash
-                  prev.coreutils
-                  prev.git
-                  prev.gh
-                  prev.curl
-                ]}
-            '';
+        installPhase = ''
+          mkdir -p $out/bin
+          cp $src $out/bin/ru
+          chmod +x $out/bin/ru
+          wrapProgram $out/bin/ru \
+            --prefix PATH : ${
+              prev.lib.makeBinPath [
+                prev.bash
+                prev.coreutils
+                prev.git
+                prev.gh
+                prev.curl
+              ]
+            }
+        '';
 
-            meta = with prev.lib; {
-              description = "Beautiful CLI tool for synchronizing GitHub repositories";
-              homepage = "https://github.com/Dicklesworthstone/repo_updater";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
+        meta = with prev.lib; {
+          description = "Beautiful CLI tool for synchronizing GitHub repositories";
+          homepage = "https://github.com/Dicklesworthstone/repo_updater";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
 
-          # dcg - destructive command guard for AI coding agents
-          destructive-command-guard = prev.stdenv.mkDerivation {
-            pname = "destructive-command-guard";
-            version = dcgVersion;
+      # dcg - destructive command guard for AI coding agents
+      destructive-command-guard = prev.stdenv.mkDerivation {
+        pname = "destructive-command-guard";
+        version = dcgVersion;
 
-            src = prev.fetchurl {
-              url = dcgSource.url;
-              sha256 = dcgSource.sha256;
-            };
+        src = prev.fetchurl {
+          url = dcgSource.url;
+          sha256 = dcgSource.sha256;
+        };
 
-            sourceRoot = ".";
+        sourceRoot = ".";
 
-            nativeBuildInputs = [ prev.xz ];
+        nativeBuildInputs = [ prev.xz ];
 
-            unpackPhase = ''
-              tar xJf $src
-            '';
+        unpackPhase = ''
+          tar xJf $src
+        '';
 
-            installPhase = ''
-              mkdir -p $out/bin
-              cp dcg $out/bin/
-              chmod +x $out/bin/dcg
-            '';
+        installPhase = ''
+          mkdir -p $out/bin
+          cp dcg $out/bin/
+          chmod +x $out/bin/dcg
+        '';
 
-            meta = with prev.lib; {
-              description = "Safety hook for AI coding agents that blocks destructive commands";
-              homepage = "https://github.com/Dicklesworthstone/destructive_command_guard";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
+        meta = with prev.lib; {
+          description = "Safety hook for AI coding agents that blocks destructive commands";
+          homepage = "https://github.com/Dicklesworthstone/destructive_command_guard";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
 
-          # cm - cass memory system
-          # Pre-built GitHub release binaries are broken (bun cross-compilation doesn't embed scripts).
-          # Build from source using bun in a plain derivation with fixed-output hash for deps.
-          cass-memory = if prev.stdenv.isLinux && prev.stdenv.hostPlatform.system == "x86_64-linux" then
+      # cm - cass memory system
+      # Pre-built GitHub release binaries are broken (bun cross-compilation doesn't embed scripts).
+      # Build from source using bun in a plain derivation with fixed-output hash for deps.
+      cass-memory =
+        if prev.stdenv.isLinux && prev.stdenv.hostPlatform.system == "x86_64-linux" then
           let
             src = prev.fetchFromGitHub {
               owner = "Dicklesworthstone";
               repo = "cass_memory_system";
-              rev = "v0.2.3";
-              hash = "sha256-sVLYU68Vw3nSIcYBGAxP/OIaJBOJ7Kmjfzn/gOSPgDs=";
+              rev = "v0.2.11";
+              hash = "sha256-CSudf1EeKPwaU7wP+mhDwKdjU/Q/lebXvjcmiMd9vfs=";
             };
             # Fixed-output derivation for bun install (needs network)
             bunDeps = prev.stdenv.mkDerivation {
               pname = "cass-memory-bun-deps";
-              version = "0.2.3";
+              version = "0.2.11";
               inherit src;
-              nativeBuildInputs = [ prev.bun prev.cacert ];
+              nativeBuildInputs = [
+                prev.bun
+                prev.cacert
+              ];
               buildPhase = ''
                 export HOME=$TMPDIR
                 bun install --frozen-lockfile --ignore-scripts
@@ -958,11 +1161,12 @@
               '';
               outputHashAlgo = "sha256";
               outputHashMode = "recursive";
-              outputHash = "sha256-BOkyY/cjghC+caQaSdcwiHwfqRsbnnyiHdPlG3yybNc=";
+              outputHash = "sha256-NyfkYUf4Wx4zbMW5WVxjFd0vi2BTT2Eu24BI5f4wAeI=";
             };
-          in prev.stdenv.mkDerivation {
+          in
+          prev.stdenv.mkDerivation {
             pname = "cass-memory";
-            version = "0.2.3";
+            version = "0.2.11";
             inherit src;
             nativeBuildInputs = [ prev.bun ];
             # Bun standalone binaries embed JS after the ELF section;
@@ -984,61 +1188,70 @@
               license = licenses.mit;
               platforms = [ "x86_64-linux" ];
             };
-          } else null;
+          }
+        else
+          null;
 
-          # caam - coding agent account manager (instant auth switching for AI coding subscriptions)
-          caam = prev.stdenv.mkDerivation {
-            pname = "caam";
-            version = caamVersion;
+      # caam - coding agent account manager (instant auth switching for AI coding subscriptions)
+      caam = prev.stdenv.mkDerivation {
+        pname = "caam";
+        version = caamVersion;
 
-            src = prev.fetchurl {
-              url = caamSource.url;
-              sha256 = caamSource.sha256;
-            };
+        src = prev.fetchurl {
+          url = caamSource.url;
+          sha256 = caamSource.sha256;
+        };
 
-            sourceRoot = ".";
+        sourceRoot = ".";
 
-            nativeBuildInputs = [ prev.gnutar ];
+        nativeBuildInputs = [ prev.gnutar ];
 
-            unpackPhase = ''
-              tar xzf $src
-            '';
+        unpackPhase = ''
+          tar xzf $src
+        '';
 
-            installPhase = ''
-              mkdir -p $out/bin
-              cp caam $out/bin/.caam-unwrapped
-              chmod +x $out/bin/.caam-unwrapped
-              # Wrapper: translate --version to subcommand (ntm health check expects --version)
-              cat > $out/bin/caam <<'WRAPPER'
-              #!/usr/bin/env bash
-              if [[ "$1" == "--version" ]]; then
-                exec "$(dirname "$0")/.caam-unwrapped" version
-              fi
-              exec "$(dirname "$0")/.caam-unwrapped" "$@"
-              WRAPPER
-              chmod +x $out/bin/caam
-            '';
+        installPhase = ''
+          mkdir -p $out/bin
+          cp caam $out/bin/.caam-unwrapped
+          chmod +x $out/bin/.caam-unwrapped
+          # Wrapper: translate --version to subcommand (ntm health check expects --version)
+          cat > $out/bin/caam <<'WRAPPER'
+          #!/usr/bin/env bash
+          if [[ "$1" == "--version" ]]; then
+            exec "$(dirname "$0")/.caam-unwrapped" version
+          fi
+          exec "$(dirname "$0")/.caam-unwrapped" "$@"
+          WRAPPER
+          chmod +x $out/bin/caam
+        '';
 
-            meta = with prev.lib; {
-              description = "Instant auth switching for AI coding tool subscriptions";
-              homepage = "https://github.com/Dicklesworthstone/coding_agent_account_manager";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
+        meta = with prev.lib; {
+          description = "Instant auth switching for AI coding tool subscriptions";
+          homepage = "https://github.com/Dicklesworthstone/coding_agent_account_manager";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
 
-          # caut - coding agent usage tracker
-          # No binary releases; requires Rust nightly. Install via: cargo install --git https://github.com/Dicklesworthstone/coding_agent_usage_tracker
-          caut = null;
+      # caut - coding agent usage tracker
+      # No binary releases; requires Rust nightly. Install via: cargo install --git https://github.com/Dicklesworthstone/coding_agent_usage_tracker
+      caut = null;
 
-          # giil - git intelligent issue linker (x86_64-linux only)
-          giil = if prev.stdenv.hostPlatform.system == "x86_64-linux" then prev.stdenv.mkDerivation {
+      # giil - git intelligent issue linker (x86_64-linux only)
+      giil =
+        if prev.stdenv.hostPlatform.system == "x86_64-linux" then
+          prev.stdenv.mkDerivation {
             pname = "giil";
-            version = "3.1.0";
+            version = "3.2.1";
 
             src = prev.fetchurl {
-              url = "https://github.com/Dicklesworthstone/giil/releases/download/v3.1.0/giil";
-              sha256 = "93c5abcc628996960a4236124ef1f9b73e561d73fb1b2b99f31286d34d3cee67";
+              url = "https://github.com/Dicklesworthstone/giil/releases/download/v3.2.1/giil";
+              sha256 = "2a1a2b8b658cd2c112406f4fd8943bffb23ba580b736ba0547d7d57703d60bd0";
             };
 
             dontUnpack = true;
@@ -1055,10 +1268,14 @@
               license = licenses.mit;
               platforms = [ "x86_64-linux" ];
             };
-          } else null;
+          }
+        else
+          null;
 
-          # pi - prompt injection detection agent (Rust)
-          pi-agent = if piSource != null then prev.stdenv.mkDerivation {
+      # pi - prompt injection detection agent (Rust)
+      pi-agent =
+        if piSource != null then
+          prev.stdenv.mkDerivation {
             pname = "pi-agent";
             version = piVersion;
 
@@ -1075,7 +1292,8 @@
 
             installPhase = ''
               mkdir -p $out/bin
-              cp pi $out/bin/
+              # v0.1.18+ nests the binary under a versioned platform subdir
+              cp pi-*/pi $out/bin/pi
               chmod +x $out/bin/pi
             '';
 
@@ -1083,12 +1301,19 @@
               description = "Prompt injection detection agent";
               homepage = "https://github.com/Dicklesworthstone/pi_agent_rust";
               license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-darwin" ];
+              platforms = [
+                "x86_64-linux"
+                "aarch64-darwin"
+              ];
             };
-          } else null;
+          }
+        else
+          null;
 
-          # xf - cross-format file converter
-          xf = if xfSource != null then prev.stdenv.mkDerivation {
+      # xf - cross-format file converter
+      xf =
+        if xfSource != null then
+          prev.stdenv.mkDerivation {
             pname = "xf";
             version = xfVersion;
 
@@ -1113,12 +1338,19 @@
               description = "Cross-format file converter";
               homepage = "https://github.com/Dicklesworthstone/xf";
               license = licenses.mit;
-              platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+              platforms = [
+                "x86_64-linux"
+                "aarch64-darwin"
+              ];
             };
-          } else null;
+          }
+        else
+          null;
 
-          # mcp-agent-mail - Rust replacement for Python mcp_agent_mail
-          mcp-agent-mail = if mcpAgentMailSource != null then prev.stdenv.mkDerivation {
+      # mcp-agent-mail - Rust replacement for Python mcp_agent_mail
+      mcp-agent-mail =
+        if mcpAgentMailSource != null then
+          prev.stdenv.mkDerivation {
             pname = "mcp-agent-mail";
             version = mcpAgentMailVersion;
 
@@ -1130,10 +1362,15 @@
             sourceRoot = ".";
 
             nativeBuildInputs = prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
-            buildInputs = prev.lib.optionals prev.stdenv.isLinux [ prev.sqlite prev.zlib prev.stdenv.cc.cc.lib prev.openssl ];
+            buildInputs = prev.lib.optionals prev.stdenv.isLinux [
+              prev.sqlite
+              prev.zlib
+              prev.stdenv.cc.cc.lib
+              prev.openssl
+            ];
 
             unpackPhase = ''
-              tar xzf $src
+              ${prev.xz}/bin/xz -d < $src | tar xf -
             '';
 
             installPhase = ''
@@ -1147,12 +1384,19 @@
               description = "MCP Agent Mail - async multi-agent coordination (Rust)";
               homepage = "https://github.com/Dicklesworthstone/mcp_agent_mail_rust";
               license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-darwin" ];
+              platforms = [
+                "x86_64-linux"
+                "aarch64-darwin"
+              ];
             };
-          } else null;
+          }
+        else
+          null;
 
-          # casr - cross agent session resumer
-          cross-agent-session-resumer = if casrSource != null then prev.stdenv.mkDerivation {
+      # casr - cross agent session resumer
+      cross-agent-session-resumer =
+        if casrSource != null then
+          prev.stdenv.mkDerivation {
             pname = "cross-agent-session-resumer";
             version = casrVersion;
 
@@ -1177,41 +1421,52 @@
               description = "Cross-agent session resumer for continuing work across AI agents";
               homepage = "https://github.com/Dicklesworthstone/cross_agent_session_resumer";
               license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-darwin" ];
+              platforms = [
+                "x86_64-linux"
+              ];
             };
-          } else null;
+          }
+        else
+          null;
 
-          # s2p - source to prompt TUI (bare binary)
-          s2p = prev.stdenv.mkDerivation {
-            pname = "s2p";
-            version = s2pVersion;
+      # s2p - source to prompt TUI (bare binary)
+      s2p = prev.stdenv.mkDerivation {
+        pname = "s2p";
+        version = s2pVersion;
 
-            src = prev.fetchurl {
-              url = s2pSource.url;
-              sha256 = s2pSource.sha256;
-            };
+        src = prev.fetchurl {
+          url = s2pSource.url;
+          sha256 = s2pSource.sha256;
+        };
 
-            dontUnpack = true;
+        dontUnpack = true;
 
-            nativeBuildInputs = prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
-            buildInputs = prev.lib.optionals prev.stdenv.isLinux [ prev.stdenv.cc.cc.lib ];
+        nativeBuildInputs = prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
+        buildInputs = prev.lib.optionals prev.stdenv.isLinux [ prev.stdenv.cc.cc.lib ];
 
-            installPhase = ''
-              mkdir -p $out/bin
-              cp $src $out/bin/s2p
-              chmod +x $out/bin/s2p
-            '';
+        installPhase = ''
+          mkdir -p $out/bin
+          cp $src $out/bin/s2p
+          chmod +x $out/bin/s2p
+        '';
 
-            meta = with prev.lib; {
-              description = "Turn code projects into LLM prompts with a TUI";
-              homepage = "https://github.com/Dicklesworthstone/source_to_prompt_tui";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
+        meta = with prev.lib; {
+          description = "Turn code projects into LLM prompts with a TUI";
+          homepage = "https://github.com/Dicklesworthstone/source_to_prompt_tui";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
 
-          # pt - process triage (intelligent process termination with Bayesian scoring)
-          process-triage = if ptSource != null then prev.stdenv.mkDerivation {
+      # pt - process triage (intelligent process termination with Bayesian scoring)
+      process-triage =
+        if ptSource != null then
+          prev.stdenv.mkDerivation {
             pname = "process-triage";
             version = ptVersion;
 
@@ -1222,8 +1477,10 @@
 
             sourceRoot = ".";
 
-            nativeBuildInputs = [ prev.gnutar ]
-              ++ prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
+            nativeBuildInputs = [
+              prev.gnutar
+            ]
+            ++ prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
             buildInputs = prev.lib.optionals prev.stdenv.isLinux [ prev.stdenv.cc.cc.lib ];
 
             unpackPhase = ''
@@ -1240,12 +1497,20 @@
               description = "Intelligent process termination with Bayesian scoring";
               homepage = "https://github.com/Dicklesworthstone/process_triage";
               license = licenses.mit;
-              platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+              platforms = [
+                "x86_64-linux"
+                "x86_64-darwin"
+                "aarch64-darwin"
+              ];
             };
-          } else null;
+          }
+        else
+          null;
 
-          # rch - remote compilation helper
-          remote-compilation-helper = if rchSource != null then prev.stdenv.mkDerivation {
+      # rch - remote compilation helper
+      remote-compilation-helper =
+        if rchSource != null then
+          prev.stdenv.mkDerivation {
             pname = "remote-compilation-helper";
             version = rchVersion;
 
@@ -1256,12 +1521,17 @@
 
             sourceRoot = ".";
 
-            nativeBuildInputs = [ prev.gnutar ]
-              ++ prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
-            buildInputs = prev.lib.optionals prev.stdenv.isLinux (with prev; [
-              openssl
-              stdenv.cc.cc.lib
-            ]);
+            nativeBuildInputs = [
+              prev.gnutar
+            ]
+            ++ prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
+            buildInputs = prev.lib.optionals prev.stdenv.isLinux (
+              with prev;
+              [
+                openssl
+                stdenv.cc.cc.lib
+              ]
+            );
 
             unpackPhase = ''
               tar xzf $src
@@ -1281,194 +1551,226 @@
               license = licenses.mit;
               platforms = [ "x86_64-linux" ];
             };
-          } else null;
+          }
+        else
+          null;
 
-          # agent-browser - browser automation CLI for AI agents (Rust CLI + Node.js Playwright daemon)
-          agent-browser = prev.stdenv.mkDerivation {
-            pname = "agent-browser";
-            version = agentBrowserVersion;
+      # agent-browser - browser automation CLI for AI agents (Rust CLI + Node.js Playwright daemon)
+      agent-browser = prev.stdenv.mkDerivation {
+        pname = "agent-browser";
+        version = agentBrowserVersion;
 
-            src = prev.fetchurl {
-              url = agentBrowserSource.url;
-              sha256 = agentBrowserSource.sha256;
+        src = prev.fetchurl {
+          url = agentBrowserSource.url;
+          sha256 = agentBrowserSource.sha256;
+        };
+
+        dontUnpack = true;
+
+        installPhase = ''
+          mkdir -p $out/bin
+          cp $src $out/bin/agent-browser
+          chmod +x $out/bin/agent-browser
+        '';
+
+        meta = with prev.lib; {
+          description = "Browser automation CLI for AI agents with compact text output";
+          homepage = "https://agent-browser.dev";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
+
+      # codex - OpenAI coding agent CLI (pre-built binary from npm)
+      codex =
+        let
+          codexVersion = "0.139.0";
+          codexSources = {
+            "x86_64-linux" = {
+              url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexVersion}-linux-x64.tgz";
+              hash = "sha256-+BO39k/esntNvU5EyaEuri8DR831bbUspGE0kmtlfxI=";
+              vendorDir = "x86_64-unknown-linux-musl";
             };
-
-            dontUnpack = true;
-
-            installPhase = ''
-              mkdir -p $out/bin
-              cp $src $out/bin/agent-browser
-              chmod +x $out/bin/agent-browser
-            '';
-
-            meta = with prev.lib; {
-              description = "Browser automation CLI for AI agents with compact text output";
-              homepage = "https://agent-browser.dev";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+            "aarch64-linux" = {
+              url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexVersion}-linux-arm64.tgz";
+              hash = "sha256-YZVnfkulHyKpobXw4qAaJVpCpXVbdAEjzmj1MO0t08o=";
+              vendorDir = "aarch64-unknown-linux-musl";
             };
-          };
-
-          # codex - OpenAI coding agent CLI (pre-built binary from npm)
-          codex = let
-            codexVersion = "0.130.0";
-            codexSources = {
-              "x86_64-linux" = {
-                url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexVersion}-linux-x64.tgz";
-                hash = "sha256-keEqVsSccCyGxcQoEc+j1RW21rwZbXC6nOolInMCqo8=";
-                vendorDir = "x86_64-unknown-linux-musl";
-              };
-              "aarch64-linux" = {
-                url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexVersion}-linux-arm64.tgz";
-                hash = "sha256-PyFyYKvoPG8P16g+BWy0U1N+Q1xnVM0zXs2TWCPY894=";
-                vendorDir = "aarch64-unknown-linux-musl";
-              };
-              "x86_64-darwin" = {
-                url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexVersion}-darwin-x64.tgz";
-                hash = "sha256-IfFh/9efq4jFvZHkDRTIlP5tStYepOvIDU/PIBMJYMI=";
-                vendorDir = "x86_64-apple-darwin";
-              };
-              "aarch64-darwin" = {
-                url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexVersion}-darwin-arm64.tgz";
-                hash = "sha256-9v7yzu6Jdwea07Mpa0wUwnB5NOa07Bqhoy1uUSGWsS0=";
-                vendorDir = "aarch64-apple-darwin";
-              };
+            "x86_64-darwin" = {
+              url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexVersion}-darwin-x64.tgz";
+              hash = "sha256-twMFprAxE+SOc9N6FlMSPTDSDRKH7OvR7LdZk8Iup4w=";
+              vendorDir = "x86_64-apple-darwin";
             };
-            system = prev.stdenv.hostPlatform.system;
-            source = codexSources.${system};
-          in prev.stdenv.mkDerivation {
-            pname = "codex";
-            version = codexVersion;
-
-            src = prev.fetchurl {
-              url = source.url;
-              hash = source.hash;
-            };
-
-            sourceRoot = ".";
-
-            unpackPhase = ''
-              tar xzf $src
-            '';
-
-            installPhase = ''
-              mkdir -p $out/bin
-              cp package/vendor/${source.vendorDir}/codex/codex $out/bin/codex
-              chmod +x $out/bin/codex
-            '';
-
-            meta = with prev.lib; {
-              description = "OpenAI Codex CLI coding agent";
-              homepage = "https://github.com/openai/codex";
-              license = licenses.asl20;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+            "aarch64-darwin" = {
+              url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexVersion}-darwin-arm64.tgz";
+              hash = "sha256-74/Ddmw5MLUsqV5U7lSGVp4kMn1xvBDnlvrTrOSSD6s=";
+              vendorDir = "aarch64-apple-darwin";
             };
           };
+          system = prev.stdenv.hostPlatform.system;
+          source = codexSources.${system};
+        in
+        prev.stdenv.mkDerivation {
+          pname = "codex";
+          version = codexVersion;
 
-          # gemini-cli - Google Gemini coding agent CLI (pre-built JS bundle)
-          gemini-cli = prev.stdenv.mkDerivation {
-            pname = "gemini-cli";
-            version = "0.43.0";
-
-            src = prev.fetchzip {
-              url = "https://github.com/google-gemini/gemini-cli/releases/download/v0.43.0/gemini-cli-bundle.zip";
-              hash = "sha256-V8ByiluPQiQFsycsdGlqPWeibxSekxiINmKaBvupjDM=";
-              stripRoot = false;
-            };
-
-            nativeBuildInputs = [ prev.makeWrapper ];
-
-            installPhase = ''
-              mkdir -p $out/lib $out/bin
-              cp -r . $out/lib/gemini-cli
-              makeWrapper ${prev.nodejs}/bin/node $out/bin/gemini \
-                --add-flags "$out/lib/gemini-cli/gemini.js"
-            '';
-
-            meta = with prev.lib; {
-              description = "Google Gemini CLI coding agent";
-              homepage = "https://github.com/google-gemini/gemini-cli";
-              license = licenses.asl20;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
+          src = prev.fetchurl {
+            url = source.url;
+            hash = source.hash;
           };
 
-          # cco - Claude Code sandbox (bubblewrap on Linux, sandbox-exec on macOS)
-          cco = prev.stdenv.mkDerivation {
-            pname = "cco";
-            version = "0-unstable-2025-06-14";
+          sourceRoot = ".";
 
-            src = prev.fetchFromGitHub {
-              owner = "nikvdp";
-              repo = "cco";
-              rev = "0b7265e4d629328a558364d86bb6a7f9a16b050b";
-              sha256 = "1jjldvid6zyky5kb6nfa5128kml8sgpkkd047s98lkqajxmy5xvf";
-            };
+          unpackPhase = ''
+            tar xzf $src
+          '';
 
-            nativeBuildInputs = [ prev.makeWrapper ];
+          installPhase = ''
+            mkdir -p $out/bin
+            cp package/vendor/${source.vendorDir}/bin/codex $out/bin/codex
+            chmod +x $out/bin/codex
+          '';
 
-            installPhase = ''
-              mkdir -p $out/share/cco $out/bin
-              cp -r . $out/share/cco/
-              chmod +x $out/share/cco/cco
-              makeWrapper $out/share/cco/cco $out/bin/cco \
-                --prefix PATH : ${prev.lib.makeBinPath ([
+          meta = with prev.lib; {
+            description = "OpenAI Codex CLI coding agent";
+            homepage = "https://github.com/openai/codex";
+            license = licenses.asl20;
+            platforms = [
+              "x86_64-linux"
+              "aarch64-linux"
+              "x86_64-darwin"
+              "aarch64-darwin"
+            ];
+          };
+        };
+
+      # gemini-cli - Google Gemini coding agent CLI (pre-built JS bundle)
+      gemini-cli = prev.stdenv.mkDerivation {
+        pname = "gemini-cli";
+        version = "0.46.0";
+
+        src = prev.fetchzip {
+          url = "https://github.com/google-gemini/gemini-cli/releases/download/v0.46.0/gemini-cli-bundle.zip";
+          hash = "sha256-rUMVRWC++JWIcJ7Jil5yxo+3xreVeXQRK5DavbrLMeQ=";
+          stripRoot = false;
+        };
+
+        nativeBuildInputs = [ prev.makeWrapper ];
+
+        installPhase = ''
+          mkdir -p $out/lib $out/bin
+          cp -r . $out/lib/gemini-cli
+          makeWrapper ${prev.nodejs}/bin/node $out/bin/gemini \
+            --add-flags "$out/lib/gemini-cli/gemini.js"
+        '';
+
+        meta = with prev.lib; {
+          description = "Google Gemini CLI coding agent";
+          homepage = "https://github.com/google-gemini/gemini-cli";
+          license = licenses.asl20;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
+
+      # cco - Claude Code sandbox (bubblewrap on Linux, sandbox-exec on macOS)
+      cco = prev.stdenv.mkDerivation {
+        pname = "cco";
+        version = "0-unstable-2025-06-14";
+
+        src = prev.fetchFromGitHub {
+          owner = "nikvdp";
+          repo = "cco";
+          rev = "0b7265e4d629328a558364d86bb6a7f9a16b050b";
+          sha256 = "1jjldvid6zyky5kb6nfa5128kml8sgpkkd047s98lkqajxmy5xvf";
+        };
+
+        nativeBuildInputs = [ prev.makeWrapper ];
+
+        installPhase = ''
+          mkdir -p $out/share/cco $out/bin
+          cp -r . $out/share/cco/
+          chmod +x $out/share/cco/cco
+          makeWrapper $out/share/cco/cco $out/bin/cco \
+            --prefix PATH : ${
+              prev.lib.makeBinPath (
+                [
                   prev.bash
                   prev.coreutils
                   prev.git
                   prev.curl
                   prev.docker-client
-                ] ++ prev.lib.optionals prev.stdenv.isLinux [ prev.bubblewrap ])}
-            '';
+                ]
+                ++ prev.lib.optionals prev.stdenv.isLinux [ prev.bubblewrap ]
+              )
+            }
+        '';
 
-            meta = with prev.lib; {
-              description = "Sandbox wrapper for Claude Code and other AI coding agents";
-              homepage = "https://github.com/nikvdp/cco";
-              license = licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-            };
-          };
+        meta = with prev.lib; {
+          description = "Sandbox wrapper for Claude Code and other AI coding agents";
+          homepage = "https://github.com/nikvdp/cco";
+          license = licenses.mit;
+          platforms = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      };
 
-          # LM Studio desktop app (Linux only, macOS uses brew cask)
-          lmstudio = if prev.stdenv.isLinux then pkgs-unstable.lmstudio else null;
+      # LM Studio desktop app (Linux only, macOS uses brew cask)
+      lmstudio = if prev.stdenv.isLinux then pkgs-unstable.lmstudio else null;
 
-          # gh CLI on stable has bugs.
-          gh = pkgs-unstable.gh;
+      # gh CLI on stable has bugs.
+      gh = pkgs-unstable.gh;
 
-          # Want the latest version of these
-          nushell = pkgs-unstable.nushell;
-          google-cloud-sdk = pkgs-unstable.google-cloud-sdk;
+      # Want the latest version of these
+      nushell = pkgs-unstable.nushell;
+      google-cloud-sdk = pkgs-unstable.google-cloud-sdk;
 
-          # direnv 2.37.1 test-fish gets SIGKILLed in the Darwin sandbox; skip tests.
-          direnv = prev.direnv.overrideAttrs (_: { doCheck = false; });
+      # direnv 2.37.1 test-fish gets SIGKILLed in the Darwin sandbox; skip tests.
+      direnv = prev.direnv.overrideAttrs (_: {
+        doCheck = false;
+      });
 
-          # pipx 1.8.0 tests/test_package_specifier.py expects PEP 508 URL specs
-          # without a space ("black@ https://...") but the current `packaging`
-          # canonicalizes with a space ("black @ https://..."), so 7 tests fail and
-          # the build aborts. The output isn't in any binary cache anymore, so a
-          # clean store (the runners) can't build it. Skip that one stale test file.
-          pipx = prev.pipx.overridePythonAttrs (old: {
-            disabledTestPaths = (old.disabledTestPaths or []) ++ [ "tests/test_package_specifier.py" ];
-          });
+      # pipx 1.8.0 tests/test_package_specifier.py expects PEP 508 URL specs
+      # without a space ("black@ https://...") but the current `packaging`
+      # canonicalizes with a space ("black @ https://..."), so 7 tests fail and
+      # the build aborts. The output isn't in any binary cache anymore, so a
+      # clean store (the runners) can't build it. Skip that one stale test file.
+      pipx = prev.pipx.overridePythonAttrs (old: {
+        disabledTestPaths = (old.disabledTestPaths or [ ]) ++ [ "tests/test_package_specifier.py" ];
+      });
 
-          # nixpkgs 26.05 wires only the node24 externals into github-runner
-          # (Node 20 is EOL). But the runner still uses node20 for its built-in
-          # hashFiles() helper (and for node20 JS actions before GitHub's
-          # 2026-06-16 cutover), exec'ing lib/externals/node20/bin/node. With
-          # node20 absent, any ${{ hashFiles(...) }} expression fails template
-          # evaluation with "An error occurred trying to start process
-          # .../node20/bin/node ... No such file or directory". The
-          # FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 runner env var only covers JS
-          # *actions*, not hashFiles. Alias node20 -> node24 so every node20
-          # invocation runs on the present node24 (GitHub's 2026-06-16 default).
-          github-runner = prev.github-runner.overrideAttrs (old: {
-            postFixup = (old.postFixup or "") + ''
-              ext="$out/lib/externals"
-              if [ -e "$ext/node24" ] && [ ! -e "$ext/node20" ]; then
-                ln -s node24 "$ext/node20"
-              fi
-            '';
-          });
+      # nixpkgs 26.05 wires only the node24 externals into github-runner
+      # (Node 20 is EOL). But the runner still uses node20 for its built-in
+      # hashFiles() helper (and for node20 JS actions before GitHub's
+      # 2026-06-16 cutover), exec'ing lib/externals/node20/bin/node. With
+      # node20 absent, any ${{ hashFiles(...) }} expression fails template
+      # evaluation with "An error occurred trying to start process
+      # .../node20/bin/node ... No such file or directory". The
+      # FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 runner env var only covers JS
+      # *actions*, not hashFiles. Alias node20 -> node24 so every node20
+      # invocation runs on the present node24 (GitHub's 2026-06-16 default).
+      github-runner = prev.github-runner.overrideAttrs (old: {
+        postFixup = (old.postFixup or "") + ''
+          ext="$out/lib/externals"
+          if [ -e "$ext/node24" ] && [ ! -e "$ext/node20" ]; then
+            ln -s node24 "$ext/node20"
+          fi
+        '';
+      });
 
-        })
+    }
+  )
 ]


### PR DESCRIPTION
## What

Bumps the pinned versions of the pre-built CLI tools in `lib/overlays.nix` to their latest upstream releases (recomputing every per-platform hash), and adds a weekly GitHub Action that automates this going forward.

### Tool updates (23)

| tool | old → new | tool | old → new |
|---|---|---|---|
| bv | 0.15.2 → 0.17.0 | pi | 0.1.9 → 0.1.18 |
| cass | 0.2.2 → 0.6.13 | xf | 0.2.0 → 0.3.2 |
| slb | 0.2.0 → 0.3.1 | mcp-agent-mail | 0.2.7 → 0.3.10 |
| brenner | 0.3.0 → 0.4.0 | casr | 0.1.1 → 0.2.3 |
| toon | 0.2.1 → 0.2.3 | pt | 2.0.5 → 2.1.0 |
| ms | 0.1.0 → 0.1.3 | rch | 1.0.10 → 1.0.41 |
| gws | 0.16.0 → 0.22.5 | ru | 1.2.1 → 1.3.1 |
| br (beads_rust) | 0.1.45 → 0.2.15 | ubs | 5.0.6 → 5.3.2 |
| ntm | 1.8.0 → 1.18.3 | cass-memory | 0.2.3 → 0.2.11 |
| dcg | 0.4.0 → 0.5.7 | giil | 3.1.0 → 3.2.1 |
| agent-browser | 0.20.13 → 0.27.3 | codex | 0.130.0 → 0.139.0 |
| gemini-cli | 0.43.0 → 0.46.0 | | |

Already latest, skipped: grepai, csctf, caam, s2p. `cco` left as-is (git-commit pin, no tagged release).

### Upstream asset/layout changes handled

- **br** — asset names dropped the `v` prefix (`br-v0.x` → `br-0.x`)
- **gws** — renamed `gws-*` → `google-workspace-cli-*`, tarball now flat (`sourceRoot = "."`)
- **mcp-agent-mail** — `.tar.gz` → `.tar.xz` (unpackPhase updated)
- **dcg** — x86_64-linux moved gnu → musl
- **xf** — upstream dropped the x86_64-darwin asset (platform removed)
- **casr** — upstream dropped the aarch64-darwin asset (platform removed)
- **codex** — binary moved to `package/vendor/<triple>/bin/codex`
- **pi** — binary now nested under a versioned platform subdir
- **ubs** — expanded to 10 modules + 13 helpers (added C# and Elixir)

### New: weekly automation

- `.github/workflows/tool-updater.yml` — Mondays 14:07 UTC + manual dispatch. Mirrors `lock-updater.yml`: Determinate Nix installer + flakehub cache, reuses the local `./.github/actions/claude-code-action` and the `ANTHROPIC_API_KEY` / `GH_TOKEN_FOR_UPDATES` secrets, then opens a PR via `peter-evans/create-pull-request` scoped to `lib/overlays.nix`.
- `.github/prompts/update-overlay-tools.md` — the instructions the bot follows (find latest releases, recompute hashes in each entry's format, handle asset/layout changes, discover the cass-memory `bunDeps` hash, run nixfmt, verify builds).

## Verification

- Full `loom` system config evaluates with no errors.
- Built and ran new binaries: codex 0.139.0, pi 0.1.18, br 0.2.15, gws 0.22.5, ubs 5.3.2, bv 0.17.0, toon 0.2.3, cass-memory.
- `nixfmt --check lib/overlays.nix` passes.

> Note: this branch contains **only** the overlay + workflow changes. The separate repo-wide nixfmt reformat in the working tree was intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)